### PR TITLE
[Bug] Fix a bug related to memset

### DIFF
--- a/gallery/how-to-guides/add-new-operator-compute-definition.py
+++ b/gallery/how-to-guides/add-new-operator-compute-definition.py
@@ -275,7 +275,7 @@ def run_task(task: Task, inputs: List[hidet.Tensor], outputs: List[hidet.Tensor]
     from hidet.runtime import CompiledFunction
 
     # build the task
-    func: CompiledFunction = hidet.driver.build_task(task, target_device='cuda')
+    func: CompiledFunction = hidet.driver.build_task(task, target_device='cpu')
     params = inputs + outputs
 
     # run the compiled task

--- a/gallery/how-to-guides/visualize-flow-graph.py
+++ b/gallery/how-to-guides/visualize-flow-graph.py
@@ -67,10 +67,7 @@ print(model)
 # Then we generate the flow graph of the model.
 
 graph = model.flow_graph_for(
-    inputs=[
-        hidet.randn([1, 128, 768], device='cuda'),
-        hidet.ones([1, 128], dtype='int32', device='cuda'),
-    ]
+    inputs=[hidet.randn([1, 128, 768]), hidet.ones([1, 128], dtype='int32')]
 )
 print(graph)
 

--- a/python/hidet/graph/tensor.py
+++ b/python/hidet/graph/tensor.py
@@ -1009,9 +1009,8 @@ def zeros(shape: Sequence[int], dtype='float32', device='cpu') -> Tensor:
     ret: Tensor
         The created tensor.
     """
-    tensor = empty(shape, dtype, device)
-    hidet.cuda.memset_async(addr=tensor.storage.addr, num_bytes=tensor.nbytes, value=0)
-    return tensor
+    dtype = data_type(dtype)
+    return full(shape, dtype.zero, dtype, device)
 
 
 def ones(shape, dtype='float32', device='cpu') -> Tensor:


### PR DESCRIPTION
Unlike cudaMemcpy, the cudaMemset does not recognize the the device and host memory, but only works for device memory.

Changed the implementation of hidet.zeros (originally, use cudaMemset, now use full operator).