### PR TITLE
[Operator] Add reduce_f16 and squeeze as Reduce's resolve variants

### DIFF
--- a/python/hidet/graph/ops/definitions/__init__.py
+++ b/python/hidet/graph/ops/definitions/__init__.py
@@ -37,7 +37,6 @@ from .arithmetic import (
     bitwise_left_shift,
 )
 from .compare import equal, less, greater, less_equal, greater_equal, logical_not, logical_and
-from .reduce import mean, min, max, sum, var, argmin, argmax
 from .transform import squeeze, unsqueeze, flatten, concat, cast, take, rearrange, strided_slice, split, pad, conv_pad
 from .pool import avg_pool2d, adaptive_avg_pool1d, adaptive_avg_pool2d, adaptive_avg_pool3d
 from .pool import max_pool2d, adaptive_max_pool1d, adaptive_max_pool2d, adaptive_max_pool3d
@@ -56,6 +55,7 @@ from .conv2d import Conv2dOp
 from .arithmetic import ErfOp, PowOp, AddOp, SubtractOp, MultiplyOp, DivideOp, WhereOp
 from .compare import EqualOp
 from .reduce import ReduceSumOp, ReduceMeanOp
+from .reduce import mean, min, max, sum, var, argmin, argmax
 from .transform import PadOp, ConcatOp
 
 from . import utils

--- a/python/hidet/graph/ops/definitions/reduce/__init__.py
+++ b/python/hidet/graph/ops/definitions/reduce/__init__.py
@@ -12,4 +12,5 @@
 from .reduce import reduce, ReduceBaseOp, ReduceTask
 from .reduce import mean, sum, var, min, max, std, prod, argmin, argmax, all, any
 from .reduce import ReduceSumOp, ReduceMeanOp
+from .reduce_f16 import reduce_f16
 from . import resolve

--- a/python/hidet/graph/ops/definitions/reduce/__init__.py
+++ b/python/hidet/graph/ops/definitions/reduce/__init__.py
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .reduce import reduce, ReduceBaseOp, ReduceTask
+from .reduce import mean, sum, var, min, max, std, prod, argmin, argmax, all, any
+from .reduce import ReduceSumOp, ReduceMeanOp
+from . import resolve

--- a/python/hidet/graph/ops/definitions/reduce/reduce.py
+++ b/python/hidet/graph/ops/definitions/reduce/reduce.py
@@ -11,9 +11,9 @@
 # limitations under the License.
 from typing import List, Union, Optional, Sequence
 
-from .arithmetic import square, sqrt
-from .utils import Task, Operator, Tensor, TensorNode, IRModule, ReduceType
-from .utils import compute, reduce, input_like, normalize_dim, arg_reduce
+from ..arithmetic import square, sqrt
+from ..utils import Task, Operator, Tensor, TensorNode, IRModule, ReduceType
+from ..utils import compute, reduce, input_like, normalize_dim, arg_reduce
 
 
 class ReduceTask(Task):
@@ -71,7 +71,7 @@ class ReduceTask(Task):
 
     def implement_cuda(self, workding_dir: str) -> IRModule:
         # pylint: disable=import-outside-toplevel
-        from ..schedules import cuda_schedule_reduce_by_default, cuda_schedule_reduce_by_warp_reduce
+        from ...schedules import cuda_schedule_reduce_by_default, cuda_schedule_reduce_by_warp_reduce
 
         rank = len(self.inputs[0].const_shape())
         if rank - 1 in self.dims:

--- a/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
+++ b/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
@@ -11,16 +11,11 @@
 # limitations under the License.
 from typing import List, Callable, Any, Union, Optional, Dict, Sequence
 from hidet.ir import IRModule
-from hidet.ir.expr import Expr
 from hidet.ir.primitives import active_mask, shfl_down_sync, shfl_sync
 from hidet.ir.compute import ReduceOperation, reduce
 from hidet.ir.layout import DataLayout, StridesLayout
-from hidet.ir.mapping import TaskMapping
 from hidet.ir.type import data_type, TensorType, TensorPointerType
-from hidet.graph.ops.definitions.matmul.batch_matmul import BatchMatmulOp
-from hidet.transforms.tools import fuse_and_pack
 from hidet.lang import f16, f32, i32, spatial, repeat, tensor, attr, grid, printf, cast, tensor_pointer
-from hidet.lang.mapping import repeat, spatial
 from hidet.lang.cuda import blockIdx, threadIdx, syncthreads, register_tensor
 from hidet.transforms.tools import add_packed_func
 from hidet.graph.ops.definitions.utils import Task, Operator, Tensor, TensorNode, InverseMap, compute, input_like, broadcast_shape, broadcast_shapes, broadcast_indices, normalize_dim, ReduceType, reduce
@@ -198,8 +193,6 @@ class ReduceF16Task(Task):
         task_layout = repeat(*repeat_shape) * spatial(*spatial_shape)
 
         grid_size = (remain_layout.num_workers + block_size - 1) // block_size
-
-        x_dtype = self.inputs[0].ttype.dtype
         accumulate_dtype = self.attributes['accumulate_dtype']
         reduce_type = self.attributes['reduce_type']
         ro = ReduceOperation.from_name(reduce_type)

--- a/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
+++ b/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
@@ -86,6 +86,7 @@ class ReduceF16Task(Task):
 
     def cuda_schedule_reduce_by_warp(self) -> IRModule:
         import hidet
+
         row_major = DataLayout.row_major
 
         warp_size = 32

--- a/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
+++ b/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
@@ -1,0 +1,293 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List, Callable, Any, Union, Optional, Dict, Sequence
+from hidet.ir import IRModule
+from hidet.ir.expr import Expr
+from hidet.ir.primitives import active_mask, shfl_down_sync, shfl_sync
+from hidet.ir.compute import ReduceOperation, reduce
+from hidet.ir.layout import DataLayout, StridesLayout
+from hidet.ir.mapping import TaskMapping
+from hidet.ir.type import data_type, TensorType, TensorPointerType
+from hidet.graph.ops.definitions.matmul.batch_matmul import BatchMatmulOp
+from hidet.transforms.tools import fuse_and_pack
+from hidet.lang import f16, f32, i32, spatial, repeat, tensor, attr, grid, printf, cast, tensor_pointer
+from hidet.lang.mapping import repeat, spatial
+from hidet.lang.cuda import blockIdx, threadIdx, syncthreads, register_tensor
+from hidet.transforms.tools import add_packed_func
+from hidet.graph.ops.definitions.utils import Task, Operator, Tensor, TensorNode, InverseMap, compute, input_like, broadcast_shape, broadcast_shapes, broadcast_indices, normalize_dim, ReduceType, reduce
+from hidet.utils import prod
+
+class ReduceF16Task(Task):
+    def __init__(self, x: TensorNode, dims: List[int], keep_dim: bool, reduce_type: ReduceType, accumulate_dtype: str = 'float32'):
+
+        x_shape = x.const_shape()
+        y_shape = []
+        for i in range(len(x_shape)):
+            if i in dims:
+                if keep_dim:
+                    y_shape.append(1)
+            else:
+                y_shape.append(x_shape[i])
+
+        def fcompute(*indices):
+            def reduce_fcompute(*reduce_indices):
+                x_indices = []
+                p = 0
+                q = 0
+                for i in range(len(x_shape)):
+                    if i not in dims:
+                        x_indices.append(indices[p])
+                        p += 1
+                    else:
+                        x_indices.append(reduce_indices[q])
+                        q += 1
+                        if keep_dim:
+                            p += 1
+                assert p == len(indices) and q == len(reduce_indices)
+                return x[x_indices]
+
+            reduce_shape = [x_shape[i] for i in dims]
+            return reduce(
+                shape=reduce_shape, fcompute=reduce_fcompute, reduce_type=reduce_type, accumulate_dtype=accumulate_dtype
+            )
+
+        y = compute(name='y', shape=y_shape, fcompute=fcompute)
+
+        self.dims: List[int] = dims
+        self.keep_dim: bool = keep_dim
+        self.reduce_type: ReduceType = reduce_type
+
+        super().__init__(
+            name='reduce_{}_f16'.format(reduce_type),
+            inputs=[x],
+            outputs=[y],
+            attributes={
+                'dims': dims,
+                'keep_dim': keep_dim,
+                'reduce_type': reduce_type,
+                'accumulate_dtype': accumulate_dtype,
+            },
+        )
+
+    def implement_cuda(self, workding_dir: str) -> IRModule:
+        rank = len(self.inputs[0].const_shape())
+        if rank - 1 in self.dims:
+            return self.cuda_schedule_reduce_by_warp()
+        else:
+            return self.cuda_schedule_reduce_by_default()
+
+    def cuda_schedule_reduce_by_warp(self) -> IRModule:
+        import hidet
+        local_layout = DataLayout.local
+        row_major = DataLayout.row_major
+        col_major = DataLayout.column_major
+        warp_size = 32
+        block_size = warp_size
+
+        x, y = self.inputs[0], self.outputs[0]
+        shape: List[int] = x.const_shape()
+        dims = self.dims
+        if self.keep_dim:
+            remain_shape = [v if i not in dims else 1 for i, v in enumerate(shape)]
+        else:
+            remain_shape = [v for i, v in enumerate(shape) if i not in dims]
+        reduce_shape = [shape[i] for i in dims]
+        shape_32bit = [s // 2 if i == len(shape) - 1 else s for i, s in enumerate(shape)]
+        remain_layout = spatial(*remain_shape)
+
+        spatial_shape = []
+        repeat_shape = []
+        for i in range(len(shape_32bit)):
+            if i == len(shape_32bit) - 1:
+                spatial_shape.append(warp_size)
+                repeat_shape.append((shape_32bit[i] + warp_size - 1) // warp_size) # num warps per row
+            elif i in dims:
+                spatial_shape.append(1)
+                repeat_shape.append(shape_32bit[i])
+            else:
+                spatial_shape.append(shape_32bit[i])
+                repeat_shape.append(1)
+        task_layout = repeat(*repeat_shape) * spatial(*spatial_shape)
+        grid_size = remain_layout.num_workers
+        accumulate_dtype = self.attributes['accumulate_dtype']
+
+        with hidet.script_module() as module:
+
+            @hidet.script
+            def reduce_kernel(
+                x: f16[x.const_shape()],
+                y: f16[y.const_shape()]
+            ):
+                attr.cuda_grid_dim = grid_size
+                attr.cuda_block_dim = block_size
+                attr.cuda_min_blocks = 1
+
+                x_f32 = tensor_pointer('float32', shape=shape_32bit)
+                x_f32 = x
+
+                reg32 = register_tensor(f32, [1])
+                regs16 = tensor_pointer('float16', shape=[2])
+                regs16= reg32
+                rv = register_tensor(accumulate_dtype, [1])
+                rv[0] = 0.0
+                for indices in task_layout.on(threadIdx.x + blockIdx.x * block_size):
+                    reg32[0] = x_f32.read(indices, protected=True)
+                    rv[0] += regs16[0]
+                    rv[0] += regs16[1]
+                # Warp reduce by shuffle down
+                delta = 16
+                mask = active_mask()
+                for i in range(5):
+                    rv[0] += shfl_down_sync(mask, rv[0], delta, 32)
+                    delta = delta // 2
+                rv[0] = shfl_sync(mask, rv[0], 0, 32)
+                if threadIdx.x == 0:
+                    for indices in remain_layout.on(blockIdx.x):
+                        y.write(indices, rv[0], protected=True)
+        ir_module = module.ir_module()
+        add_packed_func(ir_module, func=reduce_kernel, pack_func_name=self.name)
+        return ir_module
+
+    def cuda_schedule_reduce_by_default(self) -> IRModule:
+        import hidet
+
+        local_layout = DataLayout.local
+        row_major = DataLayout.row_major
+        col_major = DataLayout.column_major
+
+        x, y = self.inputs[0], self.outputs[0]
+        dims = self.dims
+        shape: List[int] = x.const_shape()
+
+        if self.keep_dim:
+            remain_shape = [v if i not in dims else 1 for i, v in enumerate(shape)]
+        else:
+            remain_shape = [v for i, v in enumerate(shape) if i not in dims]
+        shape_32bit = [s // 2 if i == len(shape) - 1 else s for i, s in enumerate(shape)]
+        # In this schedule, remain_shape[-1] == shape[-1], as the last dim is not reduced
+        remain_shape_32bit = [s // 2 if i == len(remain_shape) - 1 else s for i, s in enumerate(remain_shape)]
+        remain_extent = prod(remain_shape_32bit)
+
+        block_size = min(256, remain_extent)
+        remain_layout = spatial(*remain_shape_32bit)
+
+        spatial_shape = []
+        repeat_shape = []
+        for i in range(len(shape_32bit)):
+            if i in dims:
+                spatial_shape.append(1)
+                repeat_shape.append(shape_32bit[i])
+            else:
+                spatial_shape.append(shape_32bit[i])
+                repeat_shape.append(1)
+        task_layout = repeat(*repeat_shape) * spatial(*spatial_shape)
+
+        grid_size = (remain_layout.num_workers + block_size - 1) // block_size
+
+        x_dtype = self.inputs[0].ttype.dtype
+        accumulate_dtype = self.attributes['accumulate_dtype']
+        
+        with hidet.script_module() as module:
+            @hidet.script
+            def reduce_kernel(
+                x: f16[x.const_shape()],
+                y: f16[y.const_shape()]
+            ):
+                # Each 256-thread ThreadBlock handles 512 columns
+                attr.cuda_grid_dim = grid_size
+                attr.cuda_block_dim = block_size
+                attr.cuda_min_blocks = 1
+
+                x_f32 = tensor_pointer('float32', shape=shape_32bit)
+                y_f32 = tensor_pointer('float32', shape=remain_shape_32bit)
+                x_f32 = x
+                y_f32 = y
+
+                reg32 = register_tensor(f32, [1])
+                regs16 = tensor_pointer('float16', shape=[2])
+                regs16= reg32
+                rv = register_tensor(accumulate_dtype, [2])
+                rv[0] = 0.0
+                rv[1] = 0.0
+                for indices in task_layout.on(threadIdx.x + blockIdx.x * block_size):
+                    reg32[0] = x_f32.read(indices, protected=True)
+                    rv[0] += regs16[0]
+                    rv[1] += regs16[1]
+                regs16[0] = rv[0]
+                regs16[1] = rv[1]
+                for indices in remain_layout.on(threadIdx.x + blockIdx.x * block_size):
+                    y_f32.write(indices, reg32[0], protected=True)
+
+        ir_module = module.ir_module()
+        add_packed_func(ir_module, func=reduce_kernel, pack_func_name=self.name)
+        return ir_module
+
+
+class ReduceBaseF16Op(Operator):
+    def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keep_dim: bool, reduce_type: ReduceType):
+        rank = len(x.shape)
+        if dims is None:
+            dims = list(range(rank))
+        dims = normalize_dim(dims, rank=rank)
+        super().__init__(
+            inputs=[x],
+            task=ReduceF16Task(input_like(x, 'x'), dims, keep_dim, reduce_type),
+            attributes={'dims': dims, 'keepdims': keep_dim},
+        )
+
+class ReduceMeanF16Op(ReduceBaseF16Op):
+    def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keepdims: bool = False):
+        super().__init__(x, dims, keepdims, ReduceType.Average)
+
+
+class ReduceSumF16Op(ReduceBaseF16Op):
+    def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keepdims: bool = False):
+        super().__init__(x, dims, keepdims, ReduceType.Sum)
+
+
+class ReduceMaxF16Op(ReduceBaseF16Op):
+    def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keepdims: bool = False):
+        super().__init__(x, dims, keepdims, ReduceType.Max)
+
+
+class ReduceMinF16Op(ReduceBaseF16Op):
+    def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keepdims: bool = False):
+        super().__init__(x, dims, keepdims, ReduceType.Min)
+
+
+class ReduceOrF16Op(ReduceBaseF16Op):
+    def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keepdims: bool = False):
+        super().__init__(x, dims, keepdims, ReduceType.Or)
+
+
+class ReduceAndF16Op(ReduceBaseF16Op):
+    def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keepdims: bool = False):
+        super().__init__(x, dims, keepdims, ReduceType.And)
+
+
+class ReduceProdF16Op(ReduceBaseF16Op):
+    def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keepdims: bool = False):
+        super().__init__(x, dims, keepdims, ReduceType.Product)
+
+def reduce_f16(x: Tensor, dims: Sequence[int], keepdims: bool, reduce_type: ReduceType) -> Tensor:
+    print("reduce_f16: reduce_type=", reduce_type)
+    op_dict = {
+        ReduceType.Sum: ReduceSumF16Op,
+        ReduceType.Average: ReduceMeanF16Op,
+        ReduceType.Max: ReduceMaxF16Op,
+        ReduceType.Min: ReduceMinF16Op,
+        ReduceType.Product: ReduceProdF16Op,
+        ReduceType.Or: ReduceOrF16Op,
+        ReduceType.And: ReduceAndF16Op,
+    }
+    op = op_dict[reduce_type]
+    return op(x, dims, keepdims).get_output(0)

--- a/python/hidet/graph/ops/definitions/reduce/resolve.py
+++ b/python/hidet/graph/ops/definitions/reduce/resolve.py
@@ -1,0 +1,77 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List, Optional, Callable, Any
+from functools import lru_cache
+
+import hidet.cuda
+from hidet.ir import dtypes
+from hidet.graph.ir import Operator, Tensor
+from hidet.graph.transforms import ResolveRule, register_resolve_rule
+from hidet.utils.py import gcd, factorize, prod, cdiv
+
+from .reduce import ReduceBaseOp
+from .reduce_f16 import reduce_f16
+from ..transform import broadcast, flatten
+from ..utils import broadcast_shapes
+
+
+@register_resolve_rule(ReduceBaseOp)
+class ReduceResolveRule(ResolveRule):
+    """
+    Resolve a generic reduce operator according to the following rules, in decreasing priority:
+    1) resolve_simplify: If the size of all reduce dimensions are 1, return the input itself if keepdims=True,
+        else return Squeeze(input, axis=reduce_dims).
+    2) resolve_f16: If the input data type is float16, and the size of the last input dimension is an even number,
+        return the output of the f16 optimized reduce schedule. (Support of odd number will be added in the future)
+    3) resolve_generic: Default case, return the output of the f32 optimized reduce schedule.
+        Currently those schedules
+    """
+    def resolve_simplify(self, op: Operator) -> Optional[List[Tensor]]:
+        dims = op.attrs['dims']
+        keepdims = op.attrs['keepdims']
+        x: Tensor = op.inputs[0]
+        shape = x.shape
+        print("in resolve_simplify")
+        if not all(shape[d] == 1 for d in dims):
+            return None
+        if keepdims:
+            print("returning self")
+            return [x]
+        print("returning squeezed self")
+        return [x.squeeze(dims)]
+
+    def resolve_f16(self, op: Operator) -> Optional[List[Tensor]]:
+        print("in resolve_f16")
+        dims = op.attrs['dims']
+        keepdims = op.attrs['keepdims']
+        reduce_type = op.task.attributes['reduce_type']
+        x: Tensor = op.inputs[0]
+        last_dim = x.shape[-1]
+        if x.dtype != dtypes.float16 or last_dim % 2 != 0:
+            return None
+        print("Resolving to Reduce F16")
+        return [reduce_f16(x, dims, keepdims, reduce_type)]
+
+    def resolve_generic(self, op: Operator) -> Optional[List[Tensor]]:
+        print("in resolve_generic")
+        x: Tensor = op.inputs[0]
+        return op.outputs
+
+    def resolve(self, op: Operator) -> Optional[List[Tensor]]:
+        assert isinstance(op, ReduceBaseOp)
+        print("Resolving Reduce")
+        resolve_funcs: List[Callable[[Operator], Any]] = [self.resolve_simplify, self.resolve_f16, self.resolve_generic]
+        for resolve_func in resolve_funcs:
+            outs = resolve_func(op)
+            if outs is not None:
+                return outs
+        return None

--- a/tests/graph/operators/test_conv2d.py
+++ b/tests/graph/operators/test_conv2d.py
@@ -38,7 +38,7 @@ def torch_conv2d(data: np.ndarray, weight: np.ndarray, padding: List[int], strid
 )
 @pytest.mark.parametrize("padding", [[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]])
 @pytest.mark.parametrize("stride", [[1, 1], [2, 2], [3, 4]])
-@pytest.mark.parametrize("dilations", [[1, 1], [3, 4]])
+@pytest.mark.parametrize("dilations", [[1, 1], [2, 2], [3, 4]])
 def test_conv2d(hidet_op, n, c, h, w, oc, kx, ky, padding, stride, dilations):
     check_binary(
         a_shape=[n, c, h, w],


### PR DESCRIPTION
The original reduce schedule is not optimized for FP16 input.
1) Added an FP16-optimized reduce schedule.
2) Simplified cases where size of all reduce dimensions are 1 to squeeze.
3) Added resolve rules for 1) and 2). Move relevant files into a single directory.
4) Added tests for FP16 reduce. (Unrelated: Added an extra common test case in conv2d)