### PR TITLE
[Fix] Mark the reduce fp16 operator not fusible

### DIFF
--- a/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
+++ b/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
@@ -77,6 +77,18 @@ class ReduceF16Task(Task):
             },
         )
 
+    def allow_prologue(self) -> bool:
+        return False
+
+    def allow_epilogue(self) -> bool:
+        rank = len(self.inputs[0].const_shape())
+        if rank - 1 in self.dims:
+            # use self.cuda_schedule_reduce_by_warp
+            return True
+        else:
+            # use self.cuda_schedule_reduce_by_default
+            return False
+
     def implement_cuda(self, workding_dir: str) -> IRModule:
         rank = len(self.inputs[0].const_shape())
         if rank - 1 in self.dims:

--- a/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
+++ b/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
@@ -82,7 +82,7 @@ class ReduceF16Task(Task):
 
     def allow_epilogue(self) -> bool:
         rank = len(self.inputs[0].const_shape())
-        if rank - 1 in self.dims:
+        if rank - 1 in self.dims:   # pylint: disable=simplifiable-if-statement
             # use self.cuda_schedule_reduce_by_warp
             return True
         else:

--- a/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
+++ b/python/hidet/graph/ops/definitions/reduce/reduce_f16.py
@@ -82,7 +82,7 @@ class ReduceF16Task(Task):
 
     def allow_epilogue(self) -> bool:
         rank = len(self.inputs[0].const_shape())
-        if rank - 1 in self.dims:   # pylint: disable=simplifiable-if-statement
+        if rank - 1 in self.dims:  # pylint: disable=simplifiable-if-statement
             # use self.cuda_schedule_reduce_by_warp
             return True
         else:


### PR DESCRIPTION
The reduce fp16 operator has not been marked as not fusible. By default, all operator are allowed to be fusible with preceeding and suceeding elementwise operators. We should override `allow_prologue` and `allow_epilogue` to mark that this task does not support such fusion (because we used implicit access through pointer to the inputs/outputs).

Reproduce the error:
```python
import hidet


def demo_fusion():
    x = hidet.symbol([9, 1, 3136, 64], dtype='float16').cuda()
    y = hidet.symbol([1, 64, 1, 1], dtype='float16').cuda()
    y_2 = hidet.ops.sum(x, dims=[0])
    y_3 = hidet.ops.reshape(y_2, [1, 1, 56, 56, 64])
    y_4 = hidet.ops.rearrange(y_3, [[4], [2], [3]])
    z = y_4 + y
    y_1 = hidet.ops.relu(z)

    graph = hidet.trace_from(y_1, [x, y])
    with hidet.graph.PassContext() as ctx:
        graph_opt = hidet.graph.optimize(graph)

    print(graph)
    print(graph_opt)
    xx = hidet.randn_like(x)
    yy = hidet.randn_like(y)
    hidet.option.save_lower_ir()
    yy_1 = graph_opt(xx, yy)


if __name__ == '__main__':
    demo_fusion()
```

FYI @hjjq.