### PR TITLE
[Fixbug] Fix bugs in binary_arithmetic op and swizzle layout

### DIFF
--- a/python/hidet/graph/ops/definitions/arithmetic.py
+++ b/python/hidet/graph/ops/definitions/arithmetic.py
@@ -476,14 +476,16 @@ def binary_arithmetic(
     elif isinstance(x, float):
         x = dtypes.float32(x)
     elif isinstance(x, Tensor) and len(x.shape) == 0:
-        x = x.dtype(x.item())
+        if x.trace is None:
+            x = x.dtype(x.item())
 
     if isinstance(y, int):
         y = dtypes.int32(y)
     elif isinstance(y, float):
         y = dtypes.float32(y)
     elif isinstance(y, Tensor) and len(y.shape) == 0:
-        y = y.dtype(y.item())
+        if y.trace is None:
+            y = y.dtype(y.item())
 
     if isinstance(x, Tensor) and isinstance(y, Tensor):
         return tensor_tensor_op(x, y)

--- a/python/hidet/ir/layout.py
+++ b/python/hidet/ir/layout.py
@@ -259,7 +259,7 @@ class SwizzleDataLayout(DataLayout):
                 )
             self.regards_dim = 1 - dim
         else:
-            self.regards_dim = dim
+            self.regards_dim = regards_dim
         self.log_step = log_step
 
         if self.dim == self.regards_dim:


### PR DESCRIPTION
Symbol inputs do not have storage, so calling item() on them will result in error.