### PR TITLE
[Fixbug] Use int64 as the output of arg-reduce

### DIFF
--- a/gallery/how-to-guides/add-new-operator-compute-definition.py
+++ b/gallery/how-to-guides/add-new-operator-compute-definition.py
@@ -371,7 +371,7 @@ def arg_max_example():
         ),
     )
     task = Task('arg_max', inputs=[a], outputs=[b])
-    run_task(task, [hidet.randn([4, 3])], [hidet.empty([4], dtype='int32')])
+    run_task(task, [hidet.randn([4, 3])], [hidet.empty([4], dtype='int64')])
 
 
 arg_max_example()

--- a/python/hidet/graph/ops/definitions/reduce/reduce.py
+++ b/python/hidet/graph/ops/definitions/reduce/reduce.py
@@ -99,7 +99,7 @@ class ArgReduceTask(Task):
                 return x[x_indices]
 
             return arg_reduce(
-                extent=x_shape[dim], fcompute=reduce_fcompute, reduce_type=reduce_type, index_dtype='int32'
+                extent=x_shape[dim], fcompute=reduce_fcompute, reduce_type=reduce_type, index_dtype='int64'
             )
 
         y = compute(name='y', shape=y_shape, fcompute=fcompute)

--- a/python/hidet/ir/compute/primitives.py
+++ b/python/hidet/ir/compute/primitives.py
@@ -257,7 +257,7 @@ def compute(name, shape: Sequence[Union[int, Expr]], fcompute, layout=None) -> T
     )
 
 
-def arg_reduce(extent: Union[int, Expr], fcompute, reduce_type, index_dtype: str = 'int32') -> ScalarNode:
+def arg_reduce(extent: Union[int, Expr], fcompute, reduce_type, index_dtype: str = 'int64') -> ScalarNode:
     """
     Define an arg reduction node.
 


### PR DESCRIPTION
Fix #103. 