### PR TITLE
[Fix] Remove lambda in shfl primitives

### DIFF
--- a/python/hidet/ir/primitives/cuda/shfl.py
+++ b/python/hidet/ir/primitives/cuda/shfl.py
@@ -14,14 +14,18 @@ from hidet.ir.type import FuncType
 from hidet.utils import initialize
 
 
+def type_infer(arg_types):
+    return arg_types[1]
+
+
 @initialize()
 def register_primitive_functions():
     functions = [
         ('cuda_activemask', '__activemask', FuncType([], 'int32')),
         # T __shfl_sync(unsigned mask, T var, int srcLane, int width=warpSize)
-        ('cuda_shfl_sync', '__shfl_sync', FuncType(type_infer_func=lambda arg_types: arg_types[1])),
-        ('cuda_shfl_up_sync', '__shfl_up_sync', FuncType(type_infer_func=lambda arg_types: arg_types[1])),
-        ('cuda_shfl_down_sync', '__shfl_down_sync', FuncType(type_infer_func=lambda arg_types: arg_types[1])),
+        ('cuda_shfl_sync', '__shfl_sync', FuncType(type_infer_func=type_infer)),
+        ('cuda_shfl_up_sync', '__shfl_up_sync', FuncType(type_infer_func=type_infer)),
+        ('cuda_shfl_down_sync', '__shfl_down_sync', FuncType(type_infer_func=type_infer)),
     ]
     for name, codegen_name, func_type in functions:
         register_primitive_function(name=name, func_or_type=func_type, codegen_name=codegen_name)


### PR DESCRIPTION
The shfl primitives use lambda functions. During operator tuning, primitives will be pickled. But since lambda functions cannot be pickled, this will lead to an error when tuning operators that use the shfl primitives. There may be other primitives that have this problem as well, and in the future we may need a more comprehensive solution.