### PR TITLE
[Fixbug] Fix bug in IR Printer

### DIFF
--- a/python/hidet/ir/tools/printer.py
+++ b/python/hidet/ir/tools/printer.py
@@ -321,7 +321,7 @@ class IRPrinter(IRFunctor):
 
     def visit_ReturnStmt(self, stmt: ReturnStmt):
         doc = NewLine() + Text('return')
-        if stmt.ret_value:
+        if stmt.ret_value is not None:
             doc += ' ' + self(stmt.ret_value)
         return doc
 


### PR DESCRIPTION
Following #122 , When evaluating `Expr` as a boolean in Python, an error will be thrown.
The error will be triggered by the IR Printer when it is visiting a return statement. It intends to check if the `Expr` object is `None` but triggers `__bool__` in `Expr`.
This bug can be reproduced with `hidet.option.save_lower_ir(True)`