### PR TITLE
[Operator] Move task building into task method to allow for override

### DIFF
--- a/gallery/how-to-guides/add-new-operator-compute-definition.py
+++ b/gallery/how-to-guides/add-new-operator-compute-definition.py
@@ -275,7 +275,7 @@ def run_task(task: Task, inputs: List[hidet.Tensor], outputs: List[hidet.Tensor]
     from hidet.runtime import CompiledFunction
 
     # build the task
-    func: CompiledFunction = hidet.driver.build_task(task, target_device='cpu')
+    func: CompiledFunction = task.build(target_device='cpu')
     params = inputs + outputs
 
     # run the compiled task

--- a/python/hidet/driver.py
+++ b/python/hidet/driver.py
@@ -110,7 +110,7 @@ def _build_task_job(args):
     try:
         task, target_device, dumped_options = args
         option.restore_options(dumped_options)
-        build_task(task, target_device, load=False)
+        task.build(target_device, load=False)
         return True
     except CompilationFailed as e:
         if option.get_option('parallel_build'):

--- a/python/hidet/graph/operator.py
+++ b/python/hidet/graph/operator.py
@@ -173,7 +173,6 @@ class Operator:
         )
 
     def build_task_func(self):
-        from hidet.driver import build_task
 
         if self.task_func is None:
-            self.task_func = build_task(self.task, target_device=self.device.type, load=True)
+            self.task_func = self.task.build(target_device=self.device.type, load=True)

--- a/python/hidet/ir/task.py
+++ b/python/hidet/ir/task.py
@@ -18,6 +18,7 @@ from hidet.ir.node import Node
 from hidet.ir.expr import Expr, Var, var
 from hidet.ir.func import IRModule
 from hidet.ir.compute import ComputeNode, TensorNode, TensorInput, ScalarNode, ScalarInput, GridCompute
+from hidet.driver import build_task
 
 
 class Target:
@@ -177,6 +178,9 @@ class Task(Node):
         params += self.inputs
         params += self.outputs
         return params
+
+    def build(self, target_device='cuda', load=True) -> CompiledFunction:
+        return build_task(self, target_device=target_device, load=load)
 
     def implement(self, target: Union[Target, str], workding_dir: str) -> IRModule:
         from hidet.graph.ops.schedules.cuda.auto_scheduler import CudaAutoScheduler


### PR DESCRIPTION
I am working on a new functionality of hidet that allows external registration of tasks that is not built using `implement_cuda` nor `auto_schedule`. This allows for the following possible use cases

- certain tasks may require implementations that cannot be expressed (or too difficult) using hidet script or hidet compute expression. One example [Non-max suppresion](https://github.com/onnx/onnx/blob/main/docs/Operators.md#NonMaxSuppression)
- other libraries may have sophisticated optimizations that would allow fast and convenient integration to Hidet as tasks

To achieve this, the `build` routine for those tasks requires customization. Previously hidet assumes the same build routine and leave that as an external function. This change moves the build into a class method to allow for overrides.
