### PR TITLE
[Operator] Add the support of using external kernels in hidet

### DIFF
--- a/python/hidet/backend/build.py
+++ b/python/hidet/backend/build.py
@@ -207,6 +207,5 @@ def load_lib_func(lib_path: str, func_name: str, func_type: FuncType) -> Compile
         print("Removed the file '{}'".format(lib_path))
         os.remove(lib_path)
         raise e
-    func_name = 'hidet_{}'.format(func_name)
     packed_func = PackedFunc(param_types=list(func_type.param_types), c_func_pointer=lib[func_name])
     return CompiledFunction(name=func_name, packed_func=packed_func)

--- a/python/hidet/driver.py
+++ b/python/hidet/driver.py
@@ -178,7 +178,7 @@ def build_ir_module(
 
     if load:
         # load function
-        return load_lib_func(lib_path, func_name, func_type=func_type)
+        return load_lib_func(lib_path, 'hidet_' + func_name, func_type=func_type)
     else:
         return lib_path, func_name, func_type
 
@@ -261,7 +261,7 @@ def build_ir_module_batch(
         for build_result in build_results:
             if build_result is not None:
                 lib_path, func_name, func_type = build_result
-                funcs.append(load_lib_func(lib_path, func_name, func_type))
+                funcs.append(load_lib_func(lib_path, 'hidet_' + func_name, func_type))
             else:
                 funcs.append(None)
     if verbose:

--- a/python/hidet/graph/operator.py
+++ b/python/hidet/graph/operator.py
@@ -170,9 +170,7 @@ class Operator:
         outputs = self.dummy_outputs()
         self.imperative_run(dummy_inputs)
         args = self.task.generate_arguments(dummy_inputs, outputs)
-        return benchmark_func(
-            lambda: self.task_func(*args), warmup=warmup, number=number, repeat=repeat, median=median
-        )
+        return benchmark_func(lambda: self.task_func(*args), warmup=warmup, number=number, repeat=repeat, median=median)
 
     def build_task_func(self):
         if self.task_func is None:

--- a/python/hidet/graph/operator.py
+++ b/python/hidet/graph/operator.py
@@ -92,7 +92,8 @@ class Operator:
             for type in output_types
         ]
 
-        self.task_func(*inputs, *outputs)
+        args = self.task.generate_arguments(inputs, outputs)
+        self.task_func(*args)
 
         status = get_last_error()
         if status is not None:
@@ -168,12 +169,11 @@ class Operator:
         dummy_inputs = self.dummy_inputs()
         outputs = self.dummy_outputs()
         self.imperative_run(dummy_inputs)
+        args = self.task.generate_arguments(dummy_inputs, outputs)
         return benchmark_func(
-            lambda: self.task_func(*dummy_inputs, *outputs), warmup=warmup, number=number, repeat=repeat, median=median
+            lambda: self.task_func(*args), warmup=warmup, number=number, repeat=repeat, median=median
         )
 
     def build_task_func(self):
-        from hidet.driver import build_task
-
         if self.task_func is None:
-            self.task_func = build_task(self.task, target_device=self.device.type, load=True)
+            self.task_func = self.task.build(target=self.device.type)

--- a/python/hidet/ir/compute/primitives.py
+++ b/python/hidet/ir/compute/primitives.py
@@ -72,6 +72,10 @@ class TensorInput(TensorNode):
     def const_shape(self) -> List[int]:
         return [int(v) for v in self.ttype.shape]
 
+    @property
+    def shape(self) -> Tuple[Expr]:
+        return self.ttype.shape
+
 
 class ReduceCompute(ScalarNode):
     def __init__(

--- a/python/hidet/ir/task.py
+++ b/python/hidet/ir/task.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Union, Optional, Sequence, Callable, Tuple
 import os
 import pickle
 from hidet.ir.node import Node
+from hidet.ir.type import FuncType, VoidType
 from hidet.ir.expr import Expr, Var, var
 from hidet.ir.func import IRModule
 from hidet.ir.compute import ComputeNode, TensorNode, TensorInput, ScalarNode, ScalarInput, GridCompute
@@ -332,3 +333,18 @@ def save_task(task: Task, fname: str):
 
 def load_task(fname: str) -> Task:
     return Task.load(fname)
+
+
+def task_compiled_func_type(task: Task) -> FuncType:
+    from hidet.ir.tools import infer_type
+
+    if task.arguments:
+        args = task.arguments
+    else:
+        args = task.parameters
+
+    return FuncType(
+        param_types=[infer_type(t) for t in args],
+        ret_type=VoidType()
+    )
+

--- a/python/hidet/ir/task.py
+++ b/python/hidet/ir/task.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 # pylint: disable=import-outside-toplevel
 from __future__ import annotations
-from typing import Any, Dict, List, Union, Optional, Sequence, Callable, Tuple
+from typing import Any, Dict, List, Union, Optional, Sequence, Callable
 import os
 import pickle
 from hidet.ir.node import Node
@@ -201,6 +201,7 @@ class Task(Node):
             return list(inputs) + list(outputs)
         else:
             from hidet.ir.tools import rewrite
+
             remap = {}
             for param, arg in zip(self.parameters, list(inputs) + list(outputs)):
                 remap[param] = arg
@@ -226,6 +227,7 @@ class Task(Node):
             The compiled function.
         """
         from hidet.driver import build_task
+
         if isinstance(target, Target):
             target = target.name
         return build_task(self, target_device=target, load=True)
@@ -343,8 +345,4 @@ def task_compiled_func_type(task: Task) -> FuncType:
     else:
         args = task.parameters
 
-    return FuncType(
-        param_types=[infer_type(t) for t in args],
-        ret_type=VoidType()
-    )
-
+    return FuncType(param_types=[infer_type(t) for t in args], ret_type=VoidType())

--- a/python/hidet/ir/task.py
+++ b/python/hidet/ir/task.py
@@ -179,14 +179,17 @@ class Task(Node):
         params += self.outputs
         return params
 
-    def generate_arguments(self, params):
+    def generate_arguments(self, inputs, outputs):
         """
         Generate arguments for the compiled function of this task given the tensor parameters.
 
         Parameters
         ----------
-        params: Sequence[Tensor]
-            The actual tensors.
+        inputs: Sequence[Tensor]
+            The input tensors.
+
+        outputs: Sequence[Tensor]
+            The output tensors.
 
         Returns
         -------
@@ -194,11 +197,33 @@ class Task(Node):
             The arguments for the compiled function.
         """
         if self.arguments is None:
-            return params
+            return list(inputs) + list(outputs)
         else:
+            from hidet.ir.tools import rewrite
             remap = {}
+            for param, arg in zip(self.parameters, list(inputs) + list(outputs)):
+                remap[param] = arg
+                if param.ndim != len(arg.shape):
+                    raise ValueError(
+                        'Expect a tensor with {} dimensions, but got {} dimensions'.format(param.ndim, len(arg.shape))
+                    )
+                remap.update({param.type.shape[i]: arg.shape[i] for i in range(param.ndim)})
+            return [rewrite(arg, remap) for arg in self.arguments]
 
     def build(self, target: Union[str, Target]):
+        """
+        Build the task for the given target to a callable function.
+
+        Parameters
+        ----------
+        target: Union[str, Target]
+            The target device.
+
+        Returns
+        -------
+        func: hidet.runtime.CompiledFunction
+            The compiled function.
+        """
         from hidet.driver import build_task
         if isinstance(target, Target):
             target = target.name


### PR DESCRIPTION
This PR allows Hidet to launch kernels in external source (e.g., manually written cuda code, or vendor library like cudnn, cublas) in hidet.

## Example

### Define the external kernel and build dynamic library
Store the code in ``naive_matmul.cu``:
```c++
#include <stdio.h>
#include <cuda.h>

__global__ void naive_matmul_kernel(float* a, float *b, float *c, int M, int N, int K) {
    int i = blockIdx.x * blockDim.x + threadIdx.x;
    int j = blockIdx.y * blockDim.y + threadIdx.y;
    if (i < M && j < N) {
        float sum = 0.0;
        for (int k = 0; k < K; k++) {
            sum += a[i * K + k] * b[k * N + j];
        }
        c[i * N + j] = sum;
    }
}


extern "C" {

__host__ void naive_matmul(int32_t num_args, int32_t * __restrict__ arg_types, void* * __restrict__ args) {
    float* __restrict__ a = (float *)args[0];
    float* __restrict__ b = (float *)args[1];
    float* __restrict__ c = (float *)args[2];
    int32_t M = *(int32_t *)args[3];
    int32_t N = *(int32_t *)args[4];
    int32_t K = *(int32_t *)args[5];
    auto block_size = dim3(16, 16);
    auto grid_size = dim3((M + block_size.x - 1) / block_size.x, (N + block_size.y - 1) / block_size.y);
    naive_matmul_kernel<<<grid_size, block_size>>>(a, b, c, M, N, K);
}
}
```
Then compiles it to ``naive_matmul.so``
```console
$ /usr/local/cuda/bin/nvcc --compiler-options '-fPIC' --shared ./naive_matmul.cu -o ./naive_matmul.so
```

### Define the Task and Operator in Hidet
See our documentation ([here](https://docs.hidet.org/stable/how-to-guides/add-new-operator/index.html)) for more information about Task and Operator definition.
```python
import hidet
from hidet.graph.operator import Operator
from hidet.ir.compute import TensorInput, compute, reduce
from hidet.ir.task import Task, task_compiled_func_type
from hidet.runtime import CompiledFunction
from hidet.graph.ops.definitions.utils import input_like


class NaiveMatmulTask(Task):
    def __init__(self, a: TensorInput, b: TensorInput):
        if a.ndim != 2 or b.ndim != 2:
            raise ValueError('Only support matrix multiplication')
        c = compute(
            name='c',
            shape=[a.shape[0], b.shape[1]],
            fcompute=lambda i, j: reduce(
                shape=[a.shape[1]],
                fcompute=lambda k: a[i, k] * b[k, j],
                reduce_type='sum'
            )
        )
        super().__init__(
            name='naive_matmul', inputs=[a, b], outputs=[c],
            arguments=[
                a,
                b,
                c,
                a.shape[0],
                b.shape[1],
                a.shape[1]
            ]
        )

    def build(self, target: str) -> CompiledFunction:
        from hidet.backend import load_lib_func
        return load_lib_func(
            lib_path='./naive_matmul.so',
            func_name='naive_matmul',
            func_type=task_compiled_func_type(self)
        )


class NaiveMatmulOp(Operator):
    def __init__(self, a: hidet.Tensor, b: hidet.Tensor):
        super().__init__(
            inputs=[a, b],
            task=NaiveMatmulTask(input_like(a, 'a'), input_like(b, 'b'))
        )


def naive_matmul(a, b):
    return NaiveMatmulOp(a, b).get_output(0)


def main():
    a = hidet.ones([3, 4]).cuda()
    b = hidet.ones([4, 5]).cuda()
    c = naive_matmul(a, b)
    hidet.cuda.synchronize()
    print(a)
    print(b)
    print(c)


if __name__ == '__main__':
    main()
```

### Run the model
```console
$ python main.py
Tensor(shape=(3, 4), dtype='float32', device='cuda:0')
[[1. 1. 1. 1.]
 [1. 1. 1. 1.]
 [1. 1. 1. 1.]]
Tensor(shape=(4, 5), dtype='float32', device='cuda:0')
[[1. 1. 1. 1. 1.]
 [1. 1. 1. 1. 1.]
 [1. 1. 1. 1. 1.]
 [1. 1. 1. 1. 1.]]
Tensor(shape=(3, 5), dtype='float32', device='cuda:0')
[[4. 4. 4. 4. 4.]
 [4. 4. 4. 4. 4.]
 [4. 4. 4. 4. 4.]]
```