### PR TITLE
[IR] Add explicit unroll

### DIFF
--- a/python/hidet/ir/__init__.py
+++ b/python/hidet/ir/__init__.py
@@ -35,7 +35,8 @@ from .layout import DataLayout
 from .mapping import TaskMapping
 
 from .stmt import Stmt, DeclareStmt, EvaluateStmt, BufferStoreStmt, AssignStmt, ForStmt, IfStmt, AssertStmt, SeqStmt
-from .stmt import LetStmt, ForTaskStmt, ReturnStmt, WhileStmt, BreakStmt, ContinueStmt
+from .stmt import LetStmt, ForMappingStmt, ReturnStmt, WhileStmt, BreakStmt, ContinueStmt
+from .stmt import ForStmtAttr
 
 from .compute import TensorNode, ScalarNode
 

--- a/python/hidet/ir/mapping.py
+++ b/python/hidet/ir/mapping.py
@@ -261,6 +261,28 @@ class ComposedTaskMapping(TaskMapping):
 #     def expand_atom(w: Int, layout: TaskMapping):
 #         return layout(w)
 
+def parse_unroll(
+    unroll: str, num_loops: Optional[int] = None
+) -> List[Union[str, int]]:
+    """
+    Parse unroll string.
+
+    unroll-string:
+      unroll-spec ([','] unroll-spec)*
+    unroll-spec:
+
+
+    Parameters
+    ----------
+    unroll
+    num_loops
+
+    Returns
+    -------
+
+    """
+    pass
+
 
 def spatial_map(task_shape: Sequence[Int], ranks: Optional[Sequence[int]] = None):
     from hidet.ir.tools import simplify

--- a/python/hidet/ir/mapping.py
+++ b/python/hidet/ir/mapping.py
@@ -217,6 +217,8 @@ def repeat_map(task_shape: Sequence[Int], ranks: Optional[Sequence[int]] = None,
     else:
         assert isinstance(attrs, str)
         attrs: List[ForStmtAttr] = ForStmtAttr.parse(attrs)
+        if len(attrs) != len(task_shape):
+            raise ValueError(f"Invalid number of attributes: {len(attrs)} vs {len(task_shape)}")
     return RepeatTaskMapping(task_shape, ranks, attrs)
 
 

--- a/python/hidet/ir/stmt.py
+++ b/python/hidet/ir/stmt.py
@@ -103,6 +103,20 @@ class ForStmtAttr:
         self.unroll: Union[int, bool, None] = unroll
         self.explicit_unroll: bool = explicit_unroll
 
+    def __str__(self):
+        if self.unroll is None:
+            return '.'
+        elif isinstance(self.unroll, bool):
+            if self.explicit_unroll:
+                return 'u+'
+            else:
+                return 'u'
+        else:
+            if self.explicit_unroll:
+                return f'u{self.unroll}+'
+            else:
+                return f'u{self.unroll}'
+
     @staticmethod
     def parse(attr: str) -> List[ForStmtAttr]:
         """
@@ -167,7 +181,7 @@ class ForStmtAttr:
 class ForStmt(Stmt):
     DEFAULT_UNROLL_LIMIT = 32
 
-    def __init__(self, loop_var, extent, *, body=None, attr: Optional[ForStmtAttr] = None):
+    def __init__(self, loop_var, extent, body=None, *, attr: Optional[ForStmtAttr] = None):
         from hidet.ir.tools import simplify  # pylint: disable=import-outside-toplevel
 
         super().__init__()

--- a/python/hidet/ir/stmt.py
+++ b/python/hidet/ir/stmt.py
@@ -9,6 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 from typing import Sequence, Tuple, Any, List, Union, Optional
 import enum
 from hidet.ir.node import Node
@@ -97,20 +98,86 @@ class LetStmt(Stmt):
         self.body: Optional[Stmt] = body
 
 
+class ForStmtAttr:
+    def __init__(self, unroll=None, explicit_unroll=False):
+        self.unroll: Union[int, bool, None] = unroll
+        self.explicit_unroll: bool = explicit_unroll
+
+    @staticmethod
+    def parse(attr: str) -> List[ForStmtAttr]:
+        """
+        Parse the attribute string and return a list of ForStmtAttr.
+
+        attr-string: attr+
+        attr:
+             | unroll
+             | default
+        unroll:
+             | 'u'          # unroll
+             | 'u' INT+     # unroll with factor, e.g., u1 u2 u3. u1 indicates unroll with factor 1 (i.e., no unroll)
+             | 'u' '+'      # explicit unroll, will be unrolled by hidet instead of underlying compiler
+        default: '.'
+
+
+        Parameters
+        ----------
+        attr: str
+            The attribute string.
+
+        Returns
+        -------
+        attrs: List[ForStmtAttr]
+            The list of ForStmtAttr.
+        """
+        s = attr.replace(' ', '')
+        idx = 0
+
+        def cur() -> Optional[str]:
+            if idx >= len(s):
+                return None
+            return s[idx]
+
+        attrs: List[ForStmtAttr] = []
+        while idx < len(s):
+            if s[idx] == '.':
+                idx += 1
+                attrs.append(ForStmtAttr(unroll=None, explicit_unroll=False))
+            elif s[idx] == 'u':
+                idx += 1
+                c = cur()
+                if c == '+':
+                    attrs.append(ForStmtAttr(unroll=True, explicit_unroll=True))
+                    idx += 1
+                elif c and c.isdigit():
+                    unroll = 0
+                    while c and c.isdigit():
+                        unroll = unroll * 10 + int(c)
+                        idx += 1
+                        c = cur()
+                    if unroll == 0:
+                        raise ValueError(f"Invalid attribute string: {attr}")
+                    attrs.append(ForStmtAttr(unroll=unroll, explicit_unroll=False))
+                else:
+                    attrs.append(ForStmtAttr(unroll=True, explicit_unroll=False))
+            else:
+                raise ValueError(f"Invalid attribute string: {attr}")
+        return attrs
+
+
 class ForStmt(Stmt):
     DEFAULT_UNROLL_LIMIT = 32
 
-    def __init__(self, loop_var, extent, unroll: Optional[Union[int, bool]] = None, body=None):
+    def __init__(self, loop_var, extent, *, body=None, attr: Optional[ForStmtAttr] = None):
         from hidet.ir.tools import simplify  # pylint: disable=import-outside-toplevel
 
         super().__init__()
         self.loop_var: Var = loop_var
         self.extent: Expr = simplify(convert(extent))
-        self.unroll: Optional[Union[int, bool]] = unroll
         self.body: Optional[Stmt] = body
+        self.attr: ForStmtAttr = attr if attr else ForStmtAttr()
 
 
-class ForTaskStmt(Stmt):
+class ForMappingStmt(Stmt):
     def __init__(self, loop_vars: Sequence[Var], mapping: TaskMapping, worker: Expr, body: Stmt):
         self.loop_vars: List[Var] = list(loop_vars)
         self.mapping: TaskMapping = mapping
@@ -202,7 +269,7 @@ def asm(
     outputs: Sequence[Any] = (),
     output_inputs: Sequence[Any] = (),
     inputs: Sequence[Any] = (),
-    is_volatile=False
+    is_volatile=False,
 ):
     from hidet.ir.tools import infer_type  # pylint: disable=import-outside-toplevel
 

--- a/python/hidet/ir/tools/printer.py
+++ b/python/hidet/ir/tools/printer.py
@@ -18,7 +18,16 @@ from hidet.ir.expr import Sub, LogicalNot, LogicalOr, LogicalAnd, Let, IfThenEls
 from hidet.ir.expr import RightShift, LeftShift, BitwiseNot, BitwiseOr
 from hidet.ir.expr import BitwiseAnd, Neg, Cast, NotEqual, BitwiseXor, Reference, Dereference, Address
 from hidet.ir.stmt import SeqStmt, IfStmt, ForStmt, AssignStmt, BufferStoreStmt, EvaluateStmt, AssertStmt
-from hidet.ir.stmt import BlackBoxStmt, AsmStmt, ReturnStmt, LetStmt, DeclareStmt, ForTaskStmt, WhileStmt, ContinueStmt
+from hidet.ir.stmt import (
+    BlackBoxStmt,
+    AsmStmt,
+    ReturnStmt,
+    LetStmt,
+    DeclareStmt,
+    ForMappingStmt,
+    WhileStmt,
+    ContinueStmt,
+)
 from hidet.ir.stmt import BreakStmt, DeclareScope, LaunchKernelStmt
 from hidet.ir.mapping import RepeatTaskMapping, SpatialTaskMapping, ComposedTaskMapping
 from hidet.ir.compute import TensorNode, GridCompute, ArgReduceCompute, ReduceCompute, TensorInput, ScalarInput
@@ -262,15 +271,15 @@ class IRPrinter(IRFunctor):
     def visit_ForStmt(self, stmt: ForStmt):
         rng = Text('range(') + self(stmt.extent) + ')'
         doc = NewLine() + Text('for ') + self(stmt.loop_var) + ' in ' + rng
-        if stmt.unroll is not None:
-            if stmt.unroll:
+        if stmt.attr.unroll is not None:
+            if stmt.attr.unroll:
                 doc += '[unroll]'
             else:
                 doc += '[no-unroll]'
         doc += self(stmt.body).indent(4)
         return doc
 
-    def visit_ForTaskStmt(self, stmt: ForTaskStmt):
+    def visit_ForTaskStmt(self, stmt: ForMappingStmt):
         doc = NewLine() + Text('for ') + self(stmt.loop_vars) + ' in ' + self(stmt.mapping) + ' on ' + self(stmt.worker)
         doc += self(stmt.body).indent(4)
         return doc

--- a/python/hidet/ir/tools/printer.py
+++ b/python/hidet/ir/tools/printer.py
@@ -272,10 +272,7 @@ class IRPrinter(IRFunctor):
         rng = Text('range(') + self(stmt.extent) + ')'
         doc = NewLine() + Text('for ') + self(stmt.loop_var) + ' in ' + rng
         if stmt.attr.unroll is not None:
-            if stmt.attr.unroll:
-                doc += '[unroll]'
-            else:
-                doc += '[no-unroll]'
+            doc += '  # ' + str(stmt.attr)
         doc += self(stmt.body).indent(4)
         return doc
 

--- a/python/hidet/ir/tools/simplifier.py
+++ b/python/hidet/ir/tools/simplifier.py
@@ -139,7 +139,7 @@ class Simplifier(StmtRewriter, ExprRewriter, BaseRewriter):
             if loop_var is stmt.loop_var and body is stmt.body:
                 return stmt
             else:
-                return ForStmt(loop_var, extent, stmt.unroll, body)
+                return ForStmt(loop_var, extent, body=body, attr=stmt.attr)
 
 
 def simplify(node: Union[Stmt, Expr, int, float], repeat_limit=10):

--- a/python/hidet/lang/__init__.py
+++ b/python/hidet/lang/__init__.py
@@ -65,7 +65,7 @@ def as_tensor_pointer(
     return cast(expr, tensor_pointer(dtype, shape, layout))
 
 
-def grid(*dim_extents, unroll=None):
+def grid(*dim_extents, attrs: Optional[str] = None):
     """
     Iterate over the grid.
 
@@ -74,11 +74,8 @@ def grid(*dim_extents, unroll=None):
     dim_extents: Sequence[Expr or int]
         The length of each dimension.
 
-    unroll: Sequence[bool or int] or int or bool, optional
-        Whether to unroll the loop for each dimension.
-        If None, the loop will not be unrolled.
-        If a bool, all dimensions will be unrolled if True, or none will be unrolled if False.
-        If a sequence of bool, each dimension will be unrolled if the corresponding element is True.
+    attrs: Optional[str]
+        The attributes of each loop. See ForStmtAttr for more information.
 
     Returns
     -------

--- a/python/hidet/lang/transpiler.py
+++ b/python/hidet/lang/transpiler.py
@@ -776,7 +776,10 @@ class PythonToHidetTranslator(PythonAstFunctor):
                     attr_string = self.visit(keyword.value)
                 else:
                     raise HidetProgramError(self, call, 'Can not recognize keyword argument: {}.'.format(keyword.arg))
-            attrs = ForStmtAttr.parse(attr_string)
+            if attr_string is None:
+                attrs = [ForStmtAttr() for _ in range(len(call.args))]
+            else:
+                attrs = ForStmtAttr.parse(attr_string)
             extents = [self.visit(arg) for arg in call.args]
             declare_loop_vars(num=len(extents))
             body = visit_body()

--- a/python/hidet/lang/transpiler.py
+++ b/python/hidet/lang/transpiler.py
@@ -42,7 +42,7 @@ from ast import Index
 import astunparse
 from hidet import ir
 from hidet.ir.expr import Var
-from hidet.ir.stmt import DeclareScope
+from hidet.ir.stmt import DeclareScope, ForStmtAttr
 from hidet.ir.tools import simplify
 from hidet.ir.builders import FunctionBuilder
 from hidet.utils import red, bold, blue, str_indent
@@ -769,42 +769,19 @@ class PythonToHidetTranslator(PythonAstFunctor):
             #    ...
             # Will be translated to nested for loops (i.e., ForStmt).
             call = stmt.iter
-            unrolls: list[Union[None, int, bool]] = None
+            attr_string: Optional[str] = None
             for keyword in call.keywords:
-                if keyword.arg == 'unroll':
-                    assert unrolls is None
-                    unrolls = []
-                    value = self.visit(keyword.value)
-                    if value is None:
-                        unrolls.extend([None] * len(call.args))
-                    elif isinstance(value, bool):
-                        unrolls.extend([value] * len(call.args))
-                    elif isinstance(value, int):
-                        if len(call.args) == 1:
-                            unrolls.append(value)
-                        else:
-                            raise HidetProgramError(
-                                self, call, 'Can not use int as unroll argument when there are multiple extents.'
-                            )
-                    elif isinstance(value, (list, tuple)):
-                        if len(value) != len(call.args):
-                            raise HidetProgramError(
-                                self, call, 'Unroll argument must have the same length as the number of extents.'
-                            )
-                        unrolls.extend(value)
-                        if not all(isinstance(v, (int, bool, type(None))) for v in unrolls):
-                            raise HidetProgramError(self, call, 'Unroll argument must be int, bool or None.')
-                    else:
-                        raise HidetProgramError(self, call, 'Can not recognize keyword argument.')
+                if keyword.arg == 'attrs':
+                    assert attr_string is None
+                    attr_string = self.visit(keyword.value)
                 else:
-                    raise HidetProgramError(self, call, 'Can not recognize keyword argument.')
-            if unrolls is None:
-                unrolls = [None] * len(call.args)
+                    raise HidetProgramError(self, call, 'Can not recognize keyword argument: {}.'.format(keyword.arg))
+            attrs = ForStmtAttr.parse(attr_string)
             extents = [self.visit(arg) for arg in call.args]
             declare_loop_vars(num=len(extents))
             body = visit_body()
-            for loop_var, extent, unroll in zip(reversed(loop_vars), reversed(extents), reversed(unrolls)):
-                body = ir.ForStmt(loop_var=loop_var, extent=extent, body=body, unroll=unroll)
+            for loop_var, extent, attr in zip(reversed(loop_vars), reversed(extents), reversed(attrs)):
+                body = ir.ForStmt(loop_var=loop_var, extent=extent, body=body, attr=attr)
             self.current_scope.append(body)
         elif isinstance(stmt.iter, Call) and isinstance(stmt.iter.func, Attribute) and stmt.iter.func.attr == 'on':
             # case 3:
@@ -819,7 +796,7 @@ class PythonToHidetTranslator(PythonAstFunctor):
                 raise HidetProgramError(self, stmt.iter.func.value, 'Expect task mapping here.')
             declare_loop_vars(num=len(mapping.task_shape))
             self.current_scope.append(
-                ir.ForTaskStmt(loop_vars=loop_vars, mapping=mapping, worker=worker, body=visit_body())
+                ir.ForMappingStmt(loop_vars=loop_vars, mapping=mapping, worker=worker, body=visit_body())
             )
         else:
             msg = (

--- a/python/hidet/transforms/__init__.py
+++ b/python/hidet/transforms/__init__.py
@@ -40,10 +40,10 @@ def lower(ir_module: IRModule) -> IRModule:
         flatten_tensor_slice_pass(),
         lower_protect_access_pass(),
         lower_task_mapping_pass(),
-        explicit_unroll_pass(),
         normalize_const_tensor_pass(),
         declare_to_let_pass(),
         rule_based_simplify_pass(),  # make ir more readable
+        explicit_unroll_pass(),
         flatten_tensor_index_pass(),
         lower_special_cast_pass(),
         resolve_primitive_func_pass(),

--- a/python/hidet/transforms/__init__.py
+++ b/python/hidet/transforms/__init__.py
@@ -17,6 +17,7 @@ from .instruments import PassInstrument, SaveIRInstrument, ProfileInstrument
 from .flatten_tensor_slice import flatten_tensor_slice_pass
 from .flatten_tensor_index import flatten_tensor_index_pass
 from .generate_packed_func import generate_packed_func_pass
+from .explicit_unroll import explicit_unroll_pass
 from .import_primitive_functions import import_primitive_functions_pass
 from .simplify_stmt import simplify_stmt_pass
 from .expand_let_expr import expand_let_expr_pass
@@ -39,6 +40,7 @@ def lower(ir_module: IRModule) -> IRModule:
         flatten_tensor_slice_pass(),
         lower_protect_access_pass(),
         lower_task_mapping_pass(),
+        explicit_unroll_pass(),
         normalize_const_tensor_pass(),
         declare_to_let_pass(),
         rule_based_simplify_pass(),  # make ir more readable

--- a/python/hidet/transforms/common/scope.py
+++ b/python/hidet/transforms/common/scope.py
@@ -139,7 +139,7 @@ class IRRewriterWithScope(IRRewriter):
             self.visit(stmt.extent)
             scope.declare(stmt.loop_var)
             body = scope.wrap(self.visit(stmt.body))
-            return ForStmt(stmt.loop_var, stmt.extent, stmt.unroll, body)
+            return ForStmt(stmt.loop_var, stmt.extent, body=body, attr=stmt.attr)
 
     def visit_LetStmt(self, stmt: LetStmt):
         with self.new_scope(stmt) as scope:

--- a/python/hidet/transforms/explicit_unroll.py
+++ b/python/hidet/transforms/explicit_unroll.py
@@ -9,17 +9,66 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Union
+from typing import List, Union, Dict
 
-from hidet.ir import Stmt, ForStmt, Expr, SeqStmt
+from hidet.ir.node import Node
 from hidet.ir.dtypes import int32
-from hidet.ir.expr import Constant
+from hidet.ir.expr import Constant, Let, Var
+from hidet.ir.stmt import ForMappingStmt, LetStmt, DeclareStmt, Stmt, ForStmt, Expr, SeqStmt
 from hidet.ir.functors import IRRewriter
-from hidet.ir.tools import rewrite, simplify
+from hidet.ir.tools import simplify
 from hidet.transforms.base import Pass, FunctionBodyPass
 
 Int = Union[Expr, int]
 TaskIndex = List[Int]
+
+
+class CloneRewriter(IRRewriter):
+    """
+    A rewriter that will create a new var for each statement/expr that will declare vars
+    """
+
+    def __init__(self, remap: Dict[Node, Node]):
+        super().__init__()
+        self.memo.update(remap)
+
+    def process_var(self, v: Var):
+        visited_v = self.visit(v)
+        if visited_v is v:
+            new_var = Var(v.hint, type=v.type, name=v.name)
+        else:
+            new_var = visited_v
+        self.memo[v] = new_var
+        return new_var
+
+    def visit_ForStmt(self, stmt: ForStmt):
+        loop_var = self.process_var(stmt.loop_var)
+        extent = self.visit(stmt.extent)
+        body = self.visit(stmt.body)
+        return ForStmt(loop_var, extent, body, attr=stmt.attr)
+
+    def visit_ForTaskStmt(self, stmt: ForMappingStmt):
+        loop_vars: List[Var] = [self.process_var(v) for v in stmt.loop_vars]
+        worker = self.visit(stmt.worker)
+        body = self.visit(stmt.body)
+        return ForMappingStmt(loop_vars=loop_vars, mapping=stmt.mapping, worker=worker, body=body)
+
+    def visit_LetStmt(self, stmt: LetStmt):
+        bind_vars = [self.process_var(v) for v in stmt.bind_vars]
+        bind_values = [self.visit(bind_value) for bind_value in stmt.bind_values]
+        body = self.visit(stmt.body)
+        return LetStmt(bind_vars, bind_values, body)
+
+    def visit_DeclareStmt(self, stmt: DeclareStmt):
+        v = self.process_var(stmt.var)
+        init = self.visit(stmt.init) if stmt.init is not None else None
+        return DeclareStmt(v, init, stmt.is_static)
+
+    def visit_Let(self, e: Let):
+        v = self.process_var(e.var)
+        value = self.visit(e.value)
+        body = self.visit(e.body)
+        return Let(v, value, body)
 
 
 class ExplicitUnrollRewriter(IRRewriter):
@@ -33,10 +82,12 @@ class ExplicitUnrollRewriter(IRRewriter):
             else:
                 extent_int = int(extent_expr)
 
+            body = self.visit(stmt.body)
+
             seq: List[Stmt] = []
             for i in range(extent_int):
-                remap = {stmt.loop_var: int32(i)}
-                seq.append(rewrite(stmt.body, remap))
+                clone_rewriter = CloneRewriter(remap={stmt.loop_var: int32(i)})
+                seq.append(clone_rewriter(body))
             if len(seq) == 1:
                 return seq[0]
             else:

--- a/python/hidet/transforms/explicit_unroll.py
+++ b/python/hidet/transforms/explicit_unroll.py
@@ -1,0 +1,54 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List, Union
+
+from hidet.ir import Stmt, ForStmt, Expr, SeqStmt
+from hidet.ir.dtypes import int32
+from hidet.ir.expr import Constant
+from hidet.ir.functors import IRRewriter
+from hidet.ir.tools import rewrite, simplify
+from hidet.transforms.base import Pass, FunctionBodyPass
+
+Int = Union[Expr, int]
+TaskIndex = List[Int]
+
+
+class ExplicitUnrollRewriter(IRRewriter):
+    def visit_ForStmt(self, stmt: ForStmt):
+        if stmt.attr.unroll and stmt.attr.explicit_unroll:
+            if not isinstance(stmt.attr.unroll, bool):
+                raise NotImplementedError('Explicit unroll with unroll factor is not supported yet')
+            extent_expr: Expr = simplify(stmt.extent)
+            if not isinstance(extent_expr, Constant):
+                raise ValueError('Expect a constant extent to unroll explicitly')
+            else:
+                extent_int = int(extent_expr)
+
+            seq: List[Stmt] = []
+            for i in range(extent_int):
+                remap = {stmt.loop_var: int32(i)}
+                seq.append(rewrite(stmt.body, remap))
+            if len(seq) == 1:
+                return seq[0]
+            else:
+                return SeqStmt(seq)
+        return IRRewriter.visit_ForStmt(self, stmt)
+
+
+class ExplicitUnrollPass(FunctionBodyPass):
+    def process_body(self, stmt: Stmt) -> Stmt:
+        rewriter = ExplicitUnrollRewriter()
+        return rewriter.rewrite(stmt)
+
+
+def explicit_unroll_pass() -> Pass:
+    return ExplicitUnrollPass()

--- a/python/hidet/transforms/lower_task_mapping.py
+++ b/python/hidet/transforms/lower_task_mapping.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List, Dict, Sequence, Union, Optional
-from hidet.ir import Var, ForTaskStmt, Stmt, ForStmt, Expr, SeqStmt
+from hidet.ir import Var, ForMappingStmt, Stmt, ForStmt, Expr, SeqStmt
 from hidet.ir.expr import var
 from hidet.ir.mapping import TaskMapping, SpatialTaskMapping, RepeatTaskMapping, ComposedTaskMapping
 from hidet.transforms.base import Pass, FunctionBodyPass
@@ -73,9 +73,9 @@ class TaskMappingExpander:
         for i in range(num_loops):
             dim = mapping.ranks.index(i)
             extent = simplify(mapping.task_shape[dim])
-            unroll = mapping.unroll[dim]
+            attr = mapping.attrs[dim]
             loop_var = var('i')
-            self.loop_nests.append(ForStmt(loop_var=loop_var, extent=extent, unroll=unroll))
+            self.loop_nests.append(ForStmt(loop_var=loop_var, extent=extent, attr=attr))
             task[dim] = loop_var
         return [task]
 
@@ -93,7 +93,7 @@ class TaskMappingExpander:
 
 
 class LowerTaskMappingRewriter(IRRewriter):
-    def visit_ForTaskStmt(self, stmt: ForTaskStmt):
+    def visit_ForTaskStmt(self, stmt: ForMappingStmt):
         body = self.visit(stmt.body)
         expander = TaskMappingExpander()
         return expander.expand(mapping=stmt.mapping, worker=stmt.worker, loop_vars=stmt.loop_vars, body=body)

--- a/tests/lang/scripts/test_unroll.py
+++ b/tests/lang/scripts/test_unroll.py
@@ -41,8 +41,16 @@ def test_unroll():
                 printf("i = %d, j = %d\n", i, j)
 
             for w in range(32):
-                # unroll the first loop while keep the second loop unchanged in the repeat task mapping
+                for i, j in repeat(2, 8).spatial(4, 8).on(w):
+                    printf("i = %d, j = %d\n", i, j)
+
                 for i, j in repeat(2, 8, attrs='u.').spatial(4, 8).on(w):
+                    printf("i = %d, j = %d\n", i, j)
+
+                for i, j in repeat(2, 8, attrs='u+').spatial(4, 8).on(w):
+                    printf("i = %d, j = %d\n", i, j)
+
+                for i, j in repeat(2, 8, attrs='u').spatial(4, 8).on(w):
                     printf("i = %d, j = %d\n", i, j)
 
     ir_module = script_module.ir_module()

--- a/tests/lang/scripts/test_unroll.py
+++ b/tests/lang/scripts/test_unroll.py
@@ -28,7 +28,13 @@ def test_unroll():
             for i in grid(10, attrs='u+'):  # unroll explicitly
                 printf("i = %d\n", i)
 
-            for i in grid(10, attrs='u2'):  # unroll with factor 2
+            for i in grid(5, attrs='u+'):
+                for j in grid(i, attrs='u'):
+                    for k in grid(2, attrs='u+'):
+                        printf("i = %d, j = %d, k = %d\n", i, j, k)
+
+            extent = 10
+            for i in grid(extent, attrs='u+'):  # explicit unroll, extent must be a compilation-time constant
                 printf("i = %d\n", i)
 
             for i, j in grid(2, 5, attrs='u.'):  # unroll the first loop while keep the second loop unchanged

--- a/tests/lang/scripts/test_unroll.py
+++ b/tests/lang/scripts/test_unroll.py
@@ -47,10 +47,10 @@ def test_unroll():
                 for i, j in repeat(2, 8, attrs='u.').spatial(4, 8).on(w):
                     printf("i = %d, j = %d\n", i, j)
 
-                for i, j in repeat(2, 8, attrs='u+').spatial(4, 8).on(w):
+                for i, j in repeat(2, 8, attrs='u+.').spatial(4, 8).on(w):
                     printf("i = %d, j = %d\n", i, j)
 
-                for i, j in repeat(2, 8, attrs='u').spatial(4, 8).on(w):
+                for i, j in repeat(2, 8, attrs='.u+').spatial(4, 8).on(w):
                     printf("i = %d, j = %d\n", i, j)
 
     ir_module = script_module.ir_module()

--- a/tests/lang/scripts/test_unroll.py
+++ b/tests/lang/scripts/test_unroll.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import hidet
+
+
+def test_unroll():
+    from hidet.lang import printf, attr, grid, repeat
+
+    with hidet.script_module() as script_module:
+        @hidet.script
+        def example():
+            attr.func_kind = 'host_kernel'
+
+            for i in grid(10, unroll=True):
+                printf("i = %d\n", i)
+
+            for i in grid(10, unroll=2):
+                printf("i = %d\n", i)
+
+            for i, j in grid(2, 5, unroll=[True, None]):
+                printf("i = %d, j = %d\n", i, j)
+
+            for w in range(32):
+                for i, j in repeat(2, 8, unroll=[True, None]).spatial(4, 8).on(w):
+                    printf("i = %d, j = %d\n", i, j)
+
+    ir_module = script_module.ir_module()
+    func = hidet.driver.build_ir_module(ir_module)
+    source_code = func.source()
+    assert "#pragma unroll" in source_code
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
1. update the API to specify unroll.
2. add support for explicit unroll in hidet (expand the loop in hidet instead of using pragma unroll)

Syntax for the attr string:
```text
        attr-string: attr+
        attr:
             | unroll
             | default
        unroll:
             | 'u'          # unroll
             | 'u' INT+     # unroll with factor, e.g., u1 u2 u3. u1 indicates unroll with factor 1 (i.e., no unroll)
             | 'u' '+'      # explicit unroll, will be unrolled by hidet instead of underlying compiler
        default: '.'
```

```python
    with hidet.script_module() as script_module:
        @hidet.script
        def example():
            attr.func_kind = 'host_kernel'

            for i in grid(10, attrs='u'):   # unroll
                printf("i = %d\n", i)

            for i in grid(10, attrs='u+'):   # unroll explicitly
                printf("i = %d\n", i)

            for i in grid(10, attrs='u2'):  # unroll with factor 2
                printf("i = %d\n", i)

            for i, j in grid(2, 5, attrs='u.'):   # unroll the first loop while keep the second loop unchanged
                printf("i = %d, j = %d\n", i, j)

            for w in range(32):
                # unroll the first loop while keep the second loop unchanged in the repeat task mapping
                for i, j in repeat(2, 8, attrs='u.').spatial(4, 8).on(w):
                    printf("i = %d, j = %d\n", i, j)

```

```c++
__host__ void hidet_example() {
  #pragma unroll
  for (int32_t i = 0; (i < 10); i = (i + 1)) {
    printf("i = %d\n", i);
  } 
  printf("i = %d\n", 0);
  printf("i = %d\n", 1);
  printf("i = %d\n", 2);
  printf("i = %d\n", 3);
  printf("i = %d\n", 4);
  printf("i = %d\n", 5);
  printf("i = %d\n", 6);
  printf("i = %d\n", 7);
  printf("i = %d\n", 8);
  printf("i = %d\n", 9);
  #pragma unroll 2
  for (int32_t i_1 = 0; (i_1 < 10); i_1 = (i_1 + 1)) {
    printf("i = %d\n", i_1);
  } 
  #pragma unroll
  for (int32_t i_2 = 0; (i_2 < 2); i_2 = (i_2 + 1)) {
    for (int32_t j = 0; (j < 5); j = (j + 1)) {
      printf("i = %d, j = %d\n", i_2, j);
    } 
  } 
  for (int32_t w = 0; (w < 32); w = (w + 1)) {
    #pragma unroll
    for (int32_t i_3 = 0; (i_3 < 2); i_3 = (i_3 + 1)) {
      for (int32_t i_4 = 0; (i_4 < 8); i_4 = (i_4 + 1)) {
        printf("i = %d, j = %d\n", ((i_3 * 4) + (w / 8)), ((i_4 * 8) + (w % 8)));
      } 
    } 
  } 
}

```