### PR TITLE
change norm to use smaller inputs to reduce running time

### DIFF
--- a/tests/frontends/torch/test_torch_norm.py
+++ b/tests/frontends/torch/test_torch_norm.py
@@ -21,8 +21,8 @@ def test_layer_norm(shape, normalized_shape, dtype):
     check_module(torch.nn.LayerNorm(normalized_shape=normalized_shape), [torch.randn(shape, dtype=dtype)])
 
 
-@pytest.mark.parametrize('shape', [[1, 32, 128, 128]])
-@pytest.mark.parametrize('num_groups', [1, 4, 32])
+@pytest.mark.parametrize('shape', [[1, 4, 32, 32]])
+@pytest.mark.parametrize('num_groups', [1, 2, 4])
 @pytest.mark.parametrize('dtype', [torch.float32])
 def test_group_norm(shape, num_groups, dtype):
     check_module(torch.nn.GroupNorm(num_groups=num_groups, num_channels=shape[1]), [torch.randn(shape, dtype=dtype)])

--- a/tests/operators/test_norm.py
+++ b/tests/operators/test_norm.py
@@ -72,7 +72,7 @@ def test_instance_norm(shape):
     check_torch_unary(shape, lambda x: F.instance_norm(x), lambda x: ops.instance_norm(x), atol=1e-4, rtol=1e-4)
 
 
-@pytest.mark.parametrize('shape, num_groups', [[[1, 32, 64], 4], [[32, 4, 32], 4], [[32, 4, 32], 1]])
+@pytest.mark.parametrize('shape, num_groups', [[[1, 32, 64], 4], [[2, 4, 32], 4], [[1, 4, 32], 1]])
 def test_group_norm(shape, num_groups):
     check_torch_unary(
         shape, lambda x: F.group_norm(x, num_groups), lambda x: ops.group_norm(x, num_groups), atol=1e-4, rtol=1e-4


### PR DESCRIPTION
torch norm test was taking too long, reduce the input size to make the CI run shorter