### PR TITLE
[IR] Creation-time constant fold for constant expressions

### DIFF
--- a/python/hidet/backend/codegen.py
+++ b/python/hidet/backend/codegen.py
@@ -12,7 +12,7 @@
 from typing import Optional, List, Tuple, Dict, Union
 import os
 import numpy as np
-from hidet.ir.dialects.pattern import AnyExpr
+from hidet.ir.dialects.pattern import PlaceholderExpr
 from hidet.ir import dtypes
 from hidet.ir.node import Node
 from hidet.ir.type import DataType, PointerType, TensorPointerType, ReferenceType, TensorType, FuncType
@@ -562,7 +562,7 @@ class Codegen(ModuleFunctor, StmtFunctor, ExprFunctor, TypeFunctor):
     def visit_TensorNode(self, e: TensorNode):
         raise ValueError()
 
-    def visit_AnyExpr(self, e: AnyExpr):
+    def visit_AnyExpr(self, e: PlaceholderExpr):
         raise ValueError()
 
     def visit_NotDispatchedNode(self, n: Node):

--- a/python/hidet/backend/codegen.py
+++ b/python/hidet/backend/codegen.py
@@ -251,7 +251,7 @@ class Codegen(ModuleFunctor, StmtFunctor, ExprFunctor, TypeFunctor):
         return '(' + self(e.a) + ' ^ ' + self(e.b) + ')'
 
     def visit_BitwiseNot(self, e: BitwiseNot):
-        return '(~' + self(e.base) + ')'
+        return '(~' + self(e.a) + ')'
 
     def visit_LeftShift(self, e: LeftShift):
         return '(' + self(e.base) + ' << ' + self(e.cnt) + ')'

--- a/python/hidet/backend/codegen.py
+++ b/python/hidet/backend/codegen.py
@@ -254,10 +254,10 @@ class Codegen(ModuleFunctor, StmtFunctor, ExprFunctor, TypeFunctor):
         return '(~' + self(e.a) + ')'
 
     def visit_LeftShift(self, e: LeftShift):
-        return '(' + self(e.base) + ' << ' + self(e.cnt) + ')'
+        return '(' + self(e.a) + ' << ' + self(e.b) + ')'
 
     def visit_RightShift(self, e: RightShift):
-        return '(' + self(e.base) + ' >> ' + self(e.cnt) + ')'
+        return '(' + self(e.a) + ' >> ' + self(e.b) + ')'
 
     def visit_TensorElement(self, e: TensorElement):
         if e.protected:

--- a/python/hidet/graph/ops/definitions/compare.py
+++ b/python/hidet/graph/ops/definitions/compare.py
@@ -16,12 +16,12 @@ from .utils import Tensor
 
 class EqualOp(BinaryElementwiseOp):
     def __init__(self, x: Tensor, y: Tensor):
-        super().__init__(x, y, lambda a, b: expr.Equal(a, b), name='eq')
+        super().__init__(x, y, lambda a, b: a == b, name='eq')
 
 
 class NotEqualOp(BinaryElementwiseOp):
     def __init__(self, x: Tensor, y: Tensor):
-        super().__init__(x, y, lambda a, b: expr.NotEqual(a, b), name='ne')
+        super().__init__(x, y, lambda a, b: a != b, name='ne')
 
 
 class LessOp(BinaryElementwiseOp):
@@ -46,25 +46,25 @@ class GreaterEqualOp(BinaryElementwiseOp):
 
 class LogicalNotOp(UnaryElementwiseOp):
     def __init__(self, x: Tensor):
-        super().__init__(x, lambda a: expr.LogicalNot(a), name='not')
+        super().__init__(x, lambda a: expr.logical_not(a), name='not')
 
 
 class LogicalAndOp(BinaryElementwiseOp):
     def __init__(self, x: Tensor, y: Tensor):
-        super().__init__(x, y, lambda a, b: expr.LogicalAnd(a, b), name='and')
+        super().__init__(x, y, lambda a, b: expr.logical_and(a, b), name='and')
 
 
 class LogicalOrOp(BinaryElementwiseOp):
     def __init__(self, x: Tensor, y: Tensor):
-        super().__init__(x, y, lambda a, b: expr.LogicalOr(a, b), name='or')
+        super().__init__(x, y, lambda a, b: expr.logical_or(a, b), name='or')
 
 
 class LogicalXorOp(BinaryElementwiseOp):
     def __init__(self, x: Tensor, y: Tensor):
         def expr_logical_xor(a: Expr, b: Expr) -> Expr:
-            x = expr.LogicalAnd(a, expr.LogicalNot(b))
-            y = expr.LogicalAnd(expr.LogicalNot(a), b)
-            return expr.LogicalOr(x, y)
+            x = expr.logical_and(a, expr.logical_not(b))
+            y = expr.logical_and(expr.logical_not(a), b)
+            return expr.logical_or(x, y)
 
         super().__init__(x, y, lambda a, b: expr_logical_xor(a, b), name='xor')
 

--- a/python/hidet/graph/ops/definitions/conv1d_transpose/conv1d_transpose.py
+++ b/python/hidet/graph/ops/definitions/conv1d_transpose/conv1d_transpose.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Optional
-from hidet.ir.expr import if_then_else, LogicalAnd
+from hidet.ir.expr import if_then_else, logical_and
 from hidet.ir.compute import compute, reduce
 from hidet.graph.ops.definitions.utils import Task, Operator, Tensor, TensorNode
 from hidet.graph.ops.definitions.utils import input_like, normalize_stride, normalize_padding, normalize_kernel
@@ -51,7 +51,7 @@ class Conv1dTransposeTask(Task):
             fcompute=lambda ni, ci, li: reduce(
                 shape=[og, kernel_size],
                 fcompute=lambda ogi, ki: if_then_else(
-                    cond=LogicalAnd.join(li + p >= ki, li + p < length_in * s + ki, (li + p - ki) % s == 0),
+                    cond=logical_and(li + p >= ki, li + p < length_in * s + ki, (li + p - ki) % s == 0),
                     then_expr=(
                         data[ni, (ci // wc) * og + ogi, (li + p - ki) // s] * weight[(ci // wc) * og + ogi, ci % wc, ki]
                     ),

--- a/python/hidet/graph/ops/definitions/conv2d_transpose/conv2d_transpose.py
+++ b/python/hidet/graph/ops/definitions/conv2d_transpose/conv2d_transpose.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Sequence, Union, Tuple
-from hidet.ir.expr import if_then_else, LogicalAnd
+from hidet.ir.expr import if_then_else, logical_and
 from hidet.ir.compute import compute, reduce
 from hidet.graph.ops.definitions.utils import Task, Operator, Tensor, TensorNode
 from hidet.graph.ops.definitions.utils import input_like, normalize_stride, normalize_padding
@@ -49,7 +49,7 @@ class Conv2dTransposeTask(Task):
             fcompute=lambda ni, ci, hi, wi: reduce(
                 shape=[og, kx, ky],
                 fcompute=lambda ogi, kxi, kyi: if_then_else(
-                    cond=LogicalAnd.join(
+                    cond=logical_and(
                         hi + px0 >= kxi,
                         hi + px0 < p * sx + kxi,
                         (hi + px0 - kxi) % sx == 0,

--- a/python/hidet/graph/ops/definitions/conv2d_transpose/conv2d_transpose_gemm.py
+++ b/python/hidet/graph/ops/definitions/conv2d_transpose/conv2d_transpose_gemm.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Sequence, Union, Tuple
-from hidet.ir.expr import if_then_else, LogicalAnd
+from hidet.ir.expr import if_then_else, logical_and
 from hidet.graph.ops.definitions.utils import Task, Operator, Tensor, TensorNode
 from hidet.graph.ops.definitions.utils import input_like, normalize_stride, normalize_padding
 from hidet.ir.compute import compute
@@ -42,7 +42,7 @@ class Conv2dTransposeGemmImageTask(Task):
             xx = hi + px0 - kxi
             yy = wi + py0 - kyi
             return if_then_else(
-                cond=LogicalAnd.join(xx >= 0, xx < p * sx, xx % sx == 0, yy >= 0, yy < q * sy, yy % sy == 0),
+                cond=logical_and(xx >= 0, xx < p * sx, xx % sx == 0, yy >= 0, yy < q * sy, yy % sy == 0),
                 then_expr=data[ni, gi * og + ogi, xx // sx, yy // sy],
                 else_expr=0.0,
             )

--- a/python/hidet/graph/ops/definitions/conv3d_transpose/conv3d_transpose.py
+++ b/python/hidet/graph/ops/definitions/conv3d_transpose/conv3d_transpose.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Sequence, Union, Tuple
-from hidet.ir.expr import if_then_else, LogicalAnd
+from hidet.ir.expr import if_then_else, logical_and
 from hidet.ir.compute import compute, reduce
 from hidet.graph.ops.definitions.utils import Task, Operator, Tensor, TensorNode
 from hidet.graph.ops.definitions.utils import input_like, normalize_stride, normalize_padding
@@ -50,7 +50,7 @@ class Conv3dTransposeTask(Task):
             fcompute=lambda ni, ci, zi, hi, wi: reduce(
                 shape=[og, kz, kx, ky],
                 fcompute=lambda ogi, kzi, kxi, kyi: if_then_else(
-                    cond=LogicalAnd.join(
+                    cond=logical_and(
                         zi + pz0 >= kzi,
                         zi + pz0 < r * sz + kzi,
                         (zi + pz0 - kzi) % sz == 0,

--- a/python/hidet/graph/ops/definitions/image.py
+++ b/python/hidet/graph/ops/definitions/image.py
@@ -12,7 +12,7 @@
 from typing import Optional, List, Sequence, Union
 
 from hidet.ir.dtypes import int32
-from hidet.ir.expr import Expr, if_then_else, convert, cast, LogicalAnd, LogicalOr
+from hidet.ir.expr import Expr, if_then_else, convert, cast, logical_or, logical_and
 from hidet.ir import primitives as prim
 from .utils import Task, Operator, Tensor, TensorNode, compute, input_like
 
@@ -164,10 +164,10 @@ def resize2d_nchw_compute(
             if cubic_exclude:
                 for i in range(4):
                     weight_w[i] = if_then_else(
-                        LogicalOr.join((w_int - 1 + i) < 0, (w_int + i) > image_width), 0.0, weight_w[i]
+                        logical_or((w_int - 1 + i) < 0, (w_int + i) > image_width), 0.0, weight_w[i]
                     )
                     weight_h[i] = if_then_else(
-                        LogicalOr.join((h_int - 1 + i) < 0, (h_int + i) > image_height), 0.0, weight_h[i]
+                        logical_or((h_int - 1 + i) < 0, (h_int + i) > image_height), 0.0, weight_h[i]
                     )
                 sum_weight_w = sum(weight_w)
                 sum_weight_h = sum(weight_h)
@@ -185,7 +185,7 @@ def resize2d_nchw_compute(
             )
         if coordinate_transformation_mode == 'tf_half_pixel_for_nn':
             value = if_then_else(
-                LogicalAnd.join(0 <= h, h < image_size[0], 0 <= w, w < image_size[1]), value, extrapolation_value
+                logical_and(0 <= h, h < image_size[0], 0 <= w, w < image_size[1]), value, extrapolation_value
             )
         return value
 

--- a/python/hidet/graph/ops/definitions/pool.py
+++ b/python/hidet/graph/ops/definitions/pool.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 from typing import Union, Sequence, List, Dict, Any
 
-from hidet.ir.expr import Expr, LogicalAnd, convert, if_then_else
+from hidet.ir.expr import Expr, convert, if_then_else, logical_and
 
 from .utils import Task, Operator, Tensor, TensorNode, compute, reduce, input_like, normalize_stride, normalize_kernel
 from .utils import normalize_padding, normalize_output
@@ -31,7 +31,7 @@ class Pool2dTask(Task):
             name='pad',
             shape=[batch_size, channels, height + padding[0] + padding[2], width + padding[1] + padding[3]],
             fcompute=lambda n, c, h, w: if_then_else(
-                LogicalAnd.join(padding[0] <= h, h < height + padding[0], padding[1] <= w, w < width + padding[1]),
+                logical_and(padding[0] <= h, h < height + padding[0], padding[1] <= w, w < width + padding[1]),
                 x[n, c, h - padding[0], w - padding[1]],
                 pad_value,
             ),
@@ -70,7 +70,7 @@ class Pool3dTask(Task):
             ],
             fcompute=lambda n, c, d, h, w: (
                 if_then_else(
-                    LogicalAnd.join(
+                    logical_and(
                         padding[0] <= d,
                         d < depth + padding[0],
                         padding[1] <= h,

--- a/python/hidet/graph/ops/definitions/transform.py
+++ b/python/hidet/graph/ops/definitions/transform.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 from typing import List, Optional, Union, Sequence
 from hidet.ir.type import DataType, data_type
-from hidet.ir.expr import LogicalAnd, if_then_else, convert
+from hidet.ir.expr import LogicalAnd, if_then_else, convert, cast as ir_cast
 from hidet.ir.layout import RowMajorLayout, ColumnMajorLayout
 from hidet.ir.utils import index_deserialize, index_serialize
 from hidet.utils import prod
@@ -436,7 +436,7 @@ class CastOp(Operator):
         super().__init__(
             inputs=[x],
             attributes={'dtype': dtype},
-            task=UnaryElementwiseTask('cast', input_like(x, 'x'), op=lambda v: Cast(v, dtype)),
+            task=UnaryElementwiseTask('cast', input_like(x, 'x'), op=lambda v: ir_cast(v, dtype)),
         )
 
 

--- a/python/hidet/graph/ops/schedules/cpu/auto_scheduler.py
+++ b/python/hidet/graph/ops/schedules/cpu/auto_scheduler.py
@@ -13,7 +13,7 @@ from typing import Dict
 
 from hidet.ir.builders import FunctionBuilder
 from hidet.ir.compute import TensorNode, GridCompute
-from hidet.ir.expr import Call, Var, convert
+from hidet.ir.expr import Var, convert, call
 from hidet.ir.tools import rewrite
 from hidet.ir.stmt import Stmt, BufferStoreStmt, EvaluateStmt
 from ..auto_scheduler import AutoScheduler, ComputeExprLower
@@ -46,4 +46,4 @@ class CpuAutoScheduler(AutoScheduler):
         func_var = self.add_function(func)
 
         # call the created function in the launch function
-        return EvaluateStmt(Call(func_var, args=call_args))
+        return EvaluateStmt(call(func_var, args=call_args))

--- a/python/hidet/graph/ops/schedules/cuda/reduce.py
+++ b/python/hidet/graph/ops/schedules/cuda/reduce.py
@@ -13,7 +13,7 @@ from typing import List
 
 from hidet.ir import IRModule
 from hidet.ir.builders import FunctionBuilder
-from hidet.ir.expr import scalar_var, convert, Expr, LogicalAnd, cast
+from hidet.ir.expr import scalar_var, convert, Expr, cast, equal, logical_and
 from hidet.ir.mapping import TaskMapping
 from hidet.ir.primitives import block_idx, thread_idx
 from hidet.ir.compute import ReduceOperation
@@ -91,7 +91,7 @@ def cuda_schedule_reduce_by_warp_reduce(task: ReduceTask) -> IRModule:
         for (r,) in block_layout.worker2task(thread_idx()):
             with fb.if_then(r < reduce_extent):
                 reduce_indices = index_deserialize(r, shape=reduce_shape)
-                with fb.if_then(LogicalAnd.join_list([reduce_index.equals(0) for reduce_index in reduce_indices])):
+                with fb.if_then(logical_and(*[equal(reduce_index, 0) for reduce_index in reduce_indices])):
                     reduce_indices = [convert(0) for _ in task.dims]
                     if task.keep_dim:
                         output_indices = merge_indices(grid_indices, reduce_indices, reduce_dims=task.dims)
@@ -140,7 +140,7 @@ def cuda_schedule_reduce_by_default(task: ReduceTask) -> IRModule:
         # body
         remain_indices = remain_layout.worker2task(thread_idx() + block_idx() * block_size)[0]
         with fb.if_then(
-            LogicalAnd.join_list([remain_index < remain_shape[i] for i, remain_index in enumerate(remain_indices)])
+            logical_and(*[remain_index < remain_shape[i] for i, remain_index in enumerate(remain_indices)])
         ):
             # get the reduced value along reduce dimensions
             for reduce_indices in reduce_layout.worker2task(0):

--- a/python/hidet/ir/__init__.py
+++ b/python/hidet/ir/__init__.py
@@ -29,6 +29,7 @@ from .expr import BinaryExpr, Condition, LessThan, LessEqual, Equal, NotEqual, A
 from .expr import Let, Cast, LogicalAnd, LogicalOr, TensorElement, Call, TensorSlice, LogicalNot, Neg
 from .expr import BitwiseXor, BitwiseAnd, BitwiseNot, BitwiseOr, Dereference
 from .expr import var, scalar_var, tensor_var, is_one, is_zero, convert
+from .expr import logical_and, logical_or, logical_not, equal, less_equal, less_than, not_equal
 
 from .layout import DataLayout
 

--- a/python/hidet/ir/__init__.py
+++ b/python/hidet/ir/__init__.py
@@ -25,7 +25,7 @@ from .type import TypeNode, TensorType, DataType, FuncType, VoidType, PointerTyp
 from .type import data_type, tensor_type, tensor_pointer_type
 
 from .expr import Expr, Var, Constant
-from .expr import BinaryOp, Condition, LessThan, LessEqual, Equal, NotEqual, Add, Sub, Multiply, Div, Mod, FloorDiv
+from .expr import BinaryExpr, Condition, LessThan, LessEqual, Equal, NotEqual, Add, Sub, Multiply, Div, Mod, FloorDiv
 from .expr import Let, Cast, LogicalAnd, LogicalOr, TensorElement, Call, TensorSlice, LogicalNot, Neg
 from .expr import BitwiseXor, BitwiseAnd, BitwiseNot, BitwiseOr, Dereference
 from .expr import var, scalar_var, tensor_var, is_one, is_zero, convert

--- a/python/hidet/ir/dialects/pattern.py
+++ b/python/hidet/ir/dialects/pattern.py
@@ -16,7 +16,7 @@ from hidet.ir.node import Node
 from hidet.ir.type import TypeNode
 from hidet.ir.expr import Expr, Constant, Add, Sub, Multiply, Div, Mod, FloorDiv, LessThan, Equal, LessEqual
 from hidet.ir.expr import BitwiseXor
-from hidet.ir.expr import IfThenElse, LogicalAnd, LogicalOr, BinaryOp
+from hidet.ir.expr import IfThenElse, LogicalAnd, LogicalOr, BinaryExpr
 
 
 class PlaceholderExpr(Expr):
@@ -114,7 +114,7 @@ class PatternMatcher:
         else:
             raise NotImplementedError(f'Pattern {type(pattern)} is not implemented')
 
-    def match_CommutativeBinary(self, pattern: BinaryOp, target: Expr):
+    def match_CommutativeBinary(self, pattern: BinaryExpr, target: Expr):
         if not isinstance(target, type(pattern)):
             raise NotMatchedError(pattern, target, "Commutative binary op has not matched")
         try:
@@ -136,7 +136,7 @@ class PatternMatcher:
 
         raise NotMatchedError(pattern, target, "Commutative binary op has not matched")
 
-    def match_Binary(self, pattern: BinaryOp, target: Expr):
+    def match_Binary(self, pattern: BinaryExpr, target: Expr):
         if not isinstance(target, type(pattern)):
             raise NotMatchedError(pattern, target, "Binary op has not matched")
         with ExitStack() as stack:

--- a/python/hidet/ir/dialects/pattern.py
+++ b/python/hidet/ir/dialects/pattern.py
@@ -9,64 +9,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Sequence, Tuple, Type, Optional, List, Union, Dict, Callable, ContextManager
+from __future__ import annotations
+from typing import Any, Tuple, Optional, Dict, ContextManager
 from contextlib import ExitStack
 from hidet.ir.node import Node
-from hidet.ir.type import TypeNode, DataType, TensorType, FuncType, data_type
+from hidet.ir.type import TypeNode
 from hidet.ir.expr import Expr, Constant, Add, Sub, Multiply, Div, Mod, FloorDiv, LessThan, Equal, LessEqual
 from hidet.ir.expr import BitwiseXor
-from hidet.ir.expr import TensorElement, IfThenElse, Call, Var, LogicalAnd, LogicalOr, BinaryOp, convert, var
-from hidet.ir.compute import TensorNode, ScalarNode, ReduceOperation, ReduceCompute
-from hidet.ir.stmt import DeclareScope
-from hidet.ir.layout import StridesLayout, DataLayout
+from hidet.ir.expr import IfThenElse, LogicalAnd, LogicalOr, BinaryOp
 
 
-class PatternNode(Node):
-    # A pattern can match a series of exprs/types/other node objects
-    pass
-
-
-class StringPattern(PatternNode):
-    pass
-
-
-class TypePattern(TypeNode, PatternNode):
-    pass
-
-
-class ScalarTypePattern(TypePattern):
-    def __init__(self, allowed_types=None):
-        self.allowed_types: Optional[List[str]] = allowed_types
-
-
-class TensorTypePattern(TypePattern):
-    def __init__(self, scope=None, scalar_type=None, rank=None, shape=None, layout=None, allow_dynamic_size=False):
-        self.rank: Optional[int] = rank
-        self.scope: Optional[Union[DeclareScope, List[DeclareScope]]] = scope
-        self.scalar_type: Optional[Union[DataType, ScalarTypePattern]] = scalar_type
-        self.shape: Optional[List[Expr]] = shape
-        self.layout: Optional[DataLayout] = layout
-        self.allow_dynamic_size = allow_dynamic_size
-
-
-class ExprPattern(Expr, PatternNode):
-    pass
-
-
-class AnyExpr(ExprPattern):
-    def __init__(self, cls=None, exclude_cls=None):
-        self.cls: Optional[Type[Expr]] = cls
-        self.exclude_cls: Optional[Type[Expr]] = exclude_cls
-
-
-class UnionPattern(PatternNode):
-    def __init__(self, patterns):
-        self.patterns: List[Node] = patterns
-
-
-class OptionalPattern(PatternNode):
-    def __init__(self, pattern):
-        self.pattern = pattern
+class PlaceholderExpr(Expr):
+    def __init__(self, required_type: Optional[TypeNode] = None, require_const=False, require_non_const=False):
+        super().__init__()
+        self.required_type: Optional[TypeNode] = required_type
+        self.require_const: bool = require_const
+        self.require_non_const: bool = require_non_const
 
 
 class NotMatchedError(Exception):
@@ -76,57 +34,26 @@ class NotMatchedError(Exception):
         self.target = target
 
 
-Matchable = Optional[Union[Node, tuple]]
-
-
 class MatchContext:
-    def __init__(self, matcher: 'PatternMatcher', pattern: Node, target: Node):
-        self.matcher = matcher
-        self.matched = matcher.matched
-        self.dispatch = matcher.dispatch_table()
-        self.pattern: Matchable = pattern
-        self.target: Matchable = target
+    def __init__(self, matcher: PatternMatcher, pattern: Expr, target: Expr):
+        self.matcher: PatternMatcher = matcher
+        self.matched: Dict[Expr, Optional[Any]] = matcher.matched
+        self.pattern: Expr = pattern
+        self.target: Expr = target
 
     def __enter__(self):
-        # pylint: disable=too-many-branches
-        if self.pattern is None:
-            # None in pattern matches anything
-            return
-        if self.target is None:
-            if isinstance(self.pattern, OptionalPattern):
-                self.matched[self.pattern] = None
-                return
-            else:
-                raise NotMatchedError(self.pattern, self.target, 'Expect non-None target')
-        assert not isinstance(self.target, list), self.target
         if self.pattern in self.matched:
             if self.matched[self.pattern] is not self.target:
                 # we think the constant with the same value as the same object
                 lhs, rhs = self.matched[self.pattern], self.target
-                if isinstance(lhs, Constant) and isinstance(rhs, Constant):
-                    if lhs.value == rhs.value:
-                        return
-                if isinstance(lhs, tuple) and isinstance(rhs, tuple):
-                    # something like (None, None) with the same hash
-                    if lhs is not rhs:
-                        return
+                if isinstance(lhs, Constant) and isinstance(rhs, Constant) and lhs == rhs:
+                    return
                 raise NotMatchedError(self.pattern, self.target, 'Can not match a pattern to two different targets')
             else:
                 return
-
-        if not isinstance(self.pattern, PatternNode):
-            # put all pattern class that allow to accept other classes
-            PatternMatcher.check_type(self.pattern, self.target)
         try:
             self.matched[self.pattern] = self.target
-            if isinstance(self.pattern, DataType):
-                self.dispatch[DataType](self.matcher, self.pattern, self.target)
-            else:
-                # noinspection PyArgumentList
-                dispatched = self.dispatch.get(self.pattern.__class__, None)
-                if dispatched is None:
-                    raise NotImplementedError(f'Pattern {self.pattern} is not implemented')
-                dispatched(self.matcher, self.pattern, self.target)
+            self.matcher.match_dispatch(self.pattern, self.target)
         except NotMatchedError as e:
             # error from current <pattern, target>
             del self.matched[self.pattern]
@@ -137,8 +64,8 @@ class MatchContext:
             # error from inner <pattern, target>
             # delete the matched target for pattern
             # do not return True, propagate the exception:
-            #   1. it can be caught by pattern like UnionPattern to try other target,
-            #   2. or, it will be caught by the of PatternMatcher.__call__, indicating failure of matching.
+            #   1. it can be caught by pattern like CommutativeBinary to try other target,
+            #   2. or, it will be caught by the of PatternMatcher.match , indicating failure of matching.
             if self.pattern is not None:
                 del self.matched[self.pattern]
 
@@ -148,112 +75,60 @@ class PatternMatcher:
     invariant: every time when we enter match(...)
         0 the self.matched[...] stored the matched patterns and targets, and ongoing matching must follow them
         1 if successful, all sub-expressions of pattern have been set in self.matched[...]
-        2 if failed, it acted like we have not call this function (we treat self.matched[v] = None
-          and v not in self.matched as the same state)
+        2 if failed, it acted like we have not called this function (we treat `self.matched[v] = None`
+          and v not in `self.matched` as the same state)
     """
 
-    # pylint: disable=no-self-use
-    _dispatch_table: Dict[Type[Node], Callable[[Node, Node], None]] = None
-
-    @staticmethod
-    def dispatch_table():
-        if PatternMatcher._dispatch_table is None:
-            PatternMatcher._dispatch_table = {
-                # string
-                StringPattern: PatternMatcher.match_StringPattern,
-                # expr
-                Add: PatternMatcher.match_CommutativeBinary,
-                Sub: PatternMatcher.match_Binary,
-                Multiply: PatternMatcher.match_CommutativeBinary,
-                Div: PatternMatcher.match_Binary,
-                Mod: PatternMatcher.match_Binary,
-                BitwiseXor: PatternMatcher.match_Binary,
-                FloorDiv: PatternMatcher.match_Binary,
-                LessThan: PatternMatcher.match_Binary,
-                Equal: PatternMatcher.match_Binary,
-                LessEqual: PatternMatcher.match_Binary,
-                TensorElement: PatternMatcher.match_TensorElement,
-                IfThenElse: PatternMatcher.match_IfThenElse,
-                Call: PatternMatcher.match_Call,
-                Var: PatternMatcher.match_Var,
-                Constant: PatternMatcher.match_Constant,
-                LogicalAnd: PatternMatcher.match_CommutativeBinary,
-                LogicalOr: PatternMatcher.match_CommutativeBinary,
-                # type
-                DataType: PatternMatcher.match_DataType,
-                TensorType: PatternMatcher.match_TensorType,
-                # scope
-                # Scope: PatternMatcher.match_Scope,
-                # layout
-                DataLayout: PatternMatcher.match_DataLayout,
-                StridesLayout: PatternMatcher.match_StridesLayout,
-                # patterns
-                AnyExpr: PatternMatcher.match_AnyPattern,
-                UnionPattern: PatternMatcher.match_UnionPattern,
-                OptionalPattern: PatternMatcher.match_OptionalPattern,
-                ScalarTypePattern: PatternMatcher.match_ScalarTypePattern,
-                TensorTypePattern: PatternMatcher.match_TensorTypePattern,
-                # python containers and types
-                str: PatternMatcher.match_String,
-                list: PatternMatcher.match_Sequence,
-                tuple: PatternMatcher.match_Sequence,
-            }
-        return PatternMatcher._dispatch_table
-
     def __init__(self):
-        self.matched: Dict[Matchable, Optional[Any]] = {}
+        from hidet.ir.tools import TypeInfer
+
+        self.matched: Dict[Expr, Expr] = {}
+        self.type_infer = TypeInfer()
 
     def __call__(self, pattern, target):
+        return self.match(pattern, target)
+
+    def match(self, pattern, target):
         self.matched.clear()
         try:
-            with self.match(pattern, target):
+            with self.try_match(pattern, target):
                 pass
             return self.matched, "Matched"
         except NotMatchedError as e:
             return None, str(e)
-            # return None, str(traceback.format_exc())
 
-    def match(
-        self, pattern: Optional[Union[Node, Sequence]], target: Optional[Union[Node, Sequence]]
-    ) -> ContextManager:
+    def try_match(self, pattern: Expr, target: Expr) -> ContextManager:
         return MatchContext(self, pattern, target)
 
-    @staticmethod
-    def check_type(pattern, target, expect_target_type=None):
-        if expect_target_type is None:
-            expect_target_type = pattern.__class__
-        if not isinstance(target, expect_target_type):
-            raise NotMatchedError(
-                pattern,
-                target,
-                "Pattern expect target with type {}, but got type {}".format(expect_target_type, type(target)),
-            )
+    def match_dispatch(self, pattern: Expr, target: Expr):
+        if isinstance(pattern, (Add, Multiply, BitwiseXor, LogicalAnd, LogicalOr)):
+            self.match_CommutativeBinary(pattern, target)
+        elif isinstance(pattern, (Sub, Div, Mod, BitwiseXor, FloorDiv, LessThan, Equal, LessEqual)):
+            self.match_Binary(pattern, target)
+        elif isinstance(pattern, PlaceholderExpr):
+            self.match_PlaceholderExpr(pattern, target)
+        elif isinstance(pattern, Constant):
+            self.match_Constant(pattern, target)
+        elif isinstance(pattern, IfThenElse):
+            self.match_IfThenElse(pattern, target)
+        else:
+            raise NotImplementedError(f'Pattern {type(pattern)} is not implemented')
 
-    def check_cond(self, pattern, target, cond, message=""):
-        if not cond:
-            raise NotMatchedError(pattern, target, message)
-
-    def always_match(self, pattern, target):
-        pass
-
-    def match_StringPattern(self, pattern: StringPattern, target: Any):
-        if not isinstance(target, str):
-            raise NotMatchedError(pattern, target)
-
-    def match_CommutativeBinary(self, pattern: BinaryOp, target: BinaryOp):
-        # return self.match_Binary(pattern, target)
+    def match_CommutativeBinary(self, pattern: BinaryOp, target: Expr):
+        if not isinstance(target, type(pattern)):
+            raise NotMatchedError(pattern, target, "Commutative binary op has not matched")
         try:
             with ExitStack() as stack:
-                stack.enter_context(self.match(pattern.a, target.a))
-                stack.enter_context(self.match(pattern.b, target.b))
+                stack.enter_context(self.try_match(pattern.a, target.a))
+                stack.enter_context(self.try_match(pattern.b, target.b))
         except NotMatchedError:
             pass
         else:
             return
         try:
             with ExitStack() as stack:
-                stack.enter_context(self.match(pattern.a, target.b))
-                stack.enter_context(self.match(pattern.b, target.a))
+                stack.enter_context(self.try_match(pattern.a, target.b))
+                stack.enter_context(self.try_match(pattern.b, target.a))
         except NotMatchedError:
             pass
         else:
@@ -261,154 +136,42 @@ class PatternMatcher:
 
         raise NotMatchedError(pattern, target, "Commutative binary op has not matched")
 
-    def match_Binary(self, pattern: BinaryOp, target: BinaryOp):
+    def match_Binary(self, pattern: BinaryOp, target: Expr):
+        if not isinstance(target, type(pattern)):
+            raise NotMatchedError(pattern, target, "Binary op has not matched")
         with ExitStack() as stack:
-            stack.enter_context(self.match(pattern.a, target.a))
-            stack.enter_context(self.match(pattern.b, target.b))
+            stack.enter_context(self.try_match(pattern.a, target.a))
+            stack.enter_context(self.try_match(pattern.b, target.b))
 
-    def match_TensorElement(self, pattern: TensorElement, target: TensorElement):
+    def match_IfThenElse(self, pattern: IfThenElse, target: Expr):
+        if not isinstance(target, IfThenElse):
+            raise NotMatchedError(pattern, target, "IfThenElse has not matched")
         with ExitStack() as stack:
-            stack.enter_context(self.match(pattern.base, target.base))
-            stack.enter_context(self.match(pattern.indices, target.indices))
+            stack.enter_context(self.try_match(pattern.cond, target.cond))
+            stack.enter_context(self.try_match(pattern.then_expr, target.then_expr))
+            stack.enter_context(self.try_match(pattern.else_expr, target.else_expr))
 
-    def match_IfThenElse(self, pattern: IfThenElse, target: IfThenElse):
-        with ExitStack() as stack:
-            stack.enter_context(self.match(pattern.cond, target.cond))
-            stack.enter_context(self.match(pattern.then_expr, target.then_expr))
-            stack.enter_context(self.match(pattern.else_expr, target.else_expr))
-
-    def match_Call(self, pattern: Call, target: Call):
-        with ExitStack() as stack:
-            stack.enter_context(self.match(pattern.func_var, target.func_var))
-            stack.enter_context(self.match(pattern.args, target.args))
-
-    def match_Var(self, pattern: Var, target: Var):  # pylint: disable=unused-argument
-        if isinstance(pattern.type, FuncType):
-            return
-        # with self.match(pattern.type, target.type):
-        #     pass
-
-    def match_Constant(self, pattern: Constant, target: Constant):
-        with self.match(pattern.type, target.type):
-            pass
-        if pattern.value is None:
-            # None matches any const value
-            return
+    @staticmethod
+    def match_Constant(pattern: Constant, target: Expr):
+        if not isinstance(target, Constant):
+            raise NotMatchedError(pattern, target, "Constant has not matched")
+        if pattern.type != target.type:
+            raise NotMatchedError(pattern, target, "Constant type has not matched")
         if pattern.value != target.value:
-            raise NotMatchedError(pattern, target)
+            raise NotMatchedError(pattern, target, "Constant value has not matched")
 
-    def match_DataLayout(self, pattern, target):
-        if isinstance(target, (StridesLayout, DataLayout)):
-            pass
-        else:
-            raise NotMatchedError(pattern, target)
-
-    def match_StridesLayout(self, pattern: StridesLayout, target: StridesLayout):
-        pass
-
-    def match_AnyPattern(self, pattern: AnyExpr, target: Expr):
-        # if pattern.type is None, match any expr, otherwise match any expr with specific type
-        if pattern.cls and not isinstance(target, pattern.cls):
-            raise NotMatchedError(pattern, target)
-        if pattern.exclude_cls and isinstance(target, pattern.exclude_cls):
-            raise NotMatchedError(pattern, target)
-
-    def match_UnionPattern(self, pattern: UnionPattern, target: Node):
-        for p in pattern.patterns:
-            success = True
-            try:
-                with self.match(p, target):
-                    pass
-            except NotMatchedError:
-                success = False
-            if success:
-                return
-        raise NotMatchedError(pattern, target)
-
-    def match_OptionalPattern(self, pattern: OptionalPattern, target: Node):
-        if target is None:
-            return
-        else:
-            with self.match(pattern.pattern, target):
-                pass
-
-    # def match_Scope(self, pattern: Scope, target: Scope):
-    #     if pattern.name is not None and (pattern.name is None or pattern.name != target.name):
-    #         raise NotMatchedError(pattern, target)
-    #
-    def match_DataType(self, pattern: DataType, target: DataType):
-        if pattern.name:
-            if pattern.name != target.name:
-                raise NotMatchedError(pattern, target)
-
-    def match_TensorType(self, pattern: TensorType, target: TensorType):
-        with ExitStack() as stack:
-            stack.enter_context(self.match(pattern.dtype, target.dtype))
-            stack.enter_context(self.match(pattern.shape, target.shape))
-            stack.enter_context(self.match(pattern.layout, target.layout))
-            # stack.enter_context(self.match(pattern.scope, target.scope))
-
-    def match_ScalarTypePattern(self, pattern: ScalarTypePattern, target: DataType):
-        self.check_type(pattern, target, DataType)
-        if pattern.allowed_types is not None and target.name not in pattern.allowed_types:
-            raise NotMatchedError(pattern, target)
-
-    def match_TensorTypePattern(self, pattern: TensorTypePattern, target: TensorType):
-        self.check_type(pattern, target, TensorType)
-        with ExitStack() as stack:
-            if pattern.rank is not None and len(target.shape) != pattern.rank:
-                raise NotMatchedError(pattern, target)
-            if pattern.scope is not None:
-                if isinstance(pattern.scope, DeclareScope) and pattern.scope.name != target.scope.name:
-                    raise NotMatchedError(pattern, target)
-                if isinstance(pattern.scope, list) and target.scope.name not in [s.name for s in pattern.scope]:
-                    raise NotMatchedError(pattern, target)
-            stack.enter_context(self.match(pattern.scalar_type, target.dtype))
-            stack.enter_context(self.match(pattern.shape, target.shape))
-            stack.enter_context(self.match(pattern.layout, target.layout))
-            if not pattern.allow_dynamic_size and any(not isinstance(s, Constant) for s in target.shape):
-                raise NotMatchedError(pattern, target)
-
-    def match_Sequence(self, pattern: Sequence, target: Sequence):
-        with ExitStack() as stack:
-            if len(pattern) != len(target):
-                raise NotMatchedError(pattern, target, "length does not match")
-            for a, b in zip(pattern, target):
-                stack.enter_context(self.match(a, b))
-
-    def match_String(self, pattern: str, target: str):
-        if pattern != target:
-            raise NotMatchedError(pattern, target)
-
-
-def reduce_pattern(shape: Sequence[Union[int, Expr]], fcompute, reduce_type: str):
-    from hidet.ir.tools import collect  # pylint: disable=import-outside-toplevel
-
-    shape = convert(shape)
-    axes = [var() for _ in shape]
-    value = convert(fcompute(*axes))
-    input_tensors = collect(value, TensorNode, stop_when_found=True)
-    input_scalars = collect(value, ScalarNode, stop_when_found=True)
-    reduce_operation = ReduceOperation.from_name(reduce_type)
-    return ReduceCompute(
-        'reduce_pattern', input_tensors, input_scalars, shape, axes, value, reduce_operation, data_type('float32')
-    )
-
-
-def any_const_int():
-    return Constant(None, data_type('int32'))
-
-
-def any_const_ints(num=1):
-    return [any_const_int() for _ in range(num)]
-
-
-def any_const():
-    return AnyExpr(Constant)
-
-
-def int_vars(names):
-    return [var(name, dtype='int32') for name in names]
+    def match_PlaceholderExpr(self, pattern: PlaceholderExpr, target: Expr):
+        if pattern.required_type is not None:
+            target_type = self.type_infer(target)
+            if type(target_type) is not type(pattern.required_type):
+                raise NotMatchedError(pattern, target, "PlaceholderExpr type class has not matched")
+            if pattern.required_type.is_data_type():
+                if target_type != pattern.required_type:
+                    raise NotMatchedError(pattern, target, "PlaceholderExpr type has not matched")
+        if pattern.require_const and not isinstance(target, Constant):
+            raise NotMatchedError(pattern, target, "PlaceholderExpr require const has not matched")
+        if pattern.require_non_const and isinstance(target, Constant):
+            raise NotMatchedError(pattern, target, "PlaceholderExpr require non-const has not matched")
 
 
 def match(pattern: Node, target: Node) -> Tuple[Optional[Dict[Node, Any]], str]:

--- a/python/hidet/ir/dtypes/boolean.py
+++ b/python/hidet/ir/dtypes/boolean.py
@@ -48,6 +48,14 @@ class Boolean(DataType):
         return self.constant(False)
 
     @property
+    def true(self):
+        return self.constant(True)
+
+    @property
+    def false(self):
+        return self.constant(False)
+
+    @property
     def min_value(self):
         raise ValueError('Boolean type has no minimum value.')
 

--- a/python/hidet/ir/expr.py
+++ b/python/hidet/ir/expr.py
@@ -344,8 +344,7 @@ class TensorElement(Expr):
         self.indices: Tuple[Expr, ...] = indices
         self.protected: bool = protected
 
-        assert isinstance(base, Expr)
-        assert isinstance(indices, tuple)
+        assert isinstance(base, Expr) and isinstance(indices, tuple)
         for idx in indices:
             assert isinstance(idx, Expr)
 
@@ -362,10 +361,13 @@ class TensorSlice(Expr):
         self.starts: Tuple[Optional[Expr], ...] = starts
         self.ends: Tuple[Optional[Expr], ...] = ends
 
-        assert len(self.indices) == tensor_rank(base)
-        assert isinstance(indices, tuple)
-        assert isinstance(starts, tuple)
-        assert isinstance(ends, tuple)
+        assert isinstance(indices, tuple) and isinstance(starts, tuple) and isinstance(ends, tuple)
+        for idx in indices:
+            assert idx is None or isinstance(idx, Expr)
+        for start in starts:
+            assert start is None or isinstance(start, Expr)
+        for end in ends:
+            assert end is None or isinstance(end, Expr)
 
 
 class Call(Expr):
@@ -373,12 +375,18 @@ class Call(Expr):
         self.func_var: Var = func_var
         self.args: Tuple[Expr, ...] = args
 
+        assert isinstance(func_var, Var) and isinstance(args, tuple)
+        for arg in args:
+            assert isinstance(arg, Expr)
+
 
 class Let(Expr):
     def __init__(self, var, value, body):
         self.var: Expr = var
         self.value: Expr = value
         self.body: Expr = body
+
+        assert isinstance(var, Var) and isinstance(value, Expr) and isinstance(body, Expr)
 
 
 class Cast(Expr):
@@ -457,25 +465,28 @@ class IfThenElse(Expr):
         self.then_expr: Expr = then_expr
         self.else_expr: Expr = else_expr
 
-        assert isinstance(cond, Expr)
-        assert isinstance(then_expr, Expr)
-        assert isinstance(else_expr, Expr)
+        assert isinstance(cond, Expr) and isinstance(then_expr, Expr) and isinstance(else_expr, Expr)
 
 
 class Dereference(Expr):
     def __init__(self, expr: Expr):
         self.expr: Expr = expr
 
+        assert isinstance(expr, Expr)
+
 
 class Address(Expr):
     def __init__(self, expr: Expr):
         self.expr: Expr = expr
 
+        assert isinstance(expr, Expr)
+
 
 class Reference(Expr):
     def __init__(self, expr: Expr):
-        assert isinstance(expr, (TensorElement, Var)), "only l-value can be referenced."
         self.expr: Expr = expr
+
+        assert isinstance(expr, Expr)
 
 
 class Var(Expr):

--- a/python/hidet/ir/functors/expr_functor.py
+++ b/python/hidet/ir/functors/expr_functor.py
@@ -258,12 +258,12 @@ class ExprVisitor(ExprFunctor, BaseVisitor):
         self.visit(e.a)
 
     def visit_LeftShift(self, e: LeftShift):
-        self.visit(e.base)
-        self.visit(e.cnt)
+        self.visit(e.a)
+        self.visit(e.b)
 
     def visit_RightShift(self, e: RightShift):
-        self.visit(e.base)
-        self.visit(e.cnt)
+        self.visit(e.a)
+        self.visit(e.b)
 
     def visit_TensorElement(self, e: TensorElement):
         self.visit(e.base)
@@ -394,17 +394,17 @@ class ExprRewriter(ExprFunctor, BaseRewriter):
             return BitwiseNot(base)
 
     def visit_LeftShift(self, e: LeftShift):
-        base = self.visit(e.base)
-        cnt = self.visit(e.cnt)
-        if base is e.base and cnt is e.cnt:
+        base = self.visit(e.a)
+        cnt = self.visit(e.b)
+        if base is e.a and cnt is e.b:
             return e
         else:
             return LeftShift(base, cnt)
 
     def visit_RightShift(self, e: RightShift):
-        base = self.visit(e.base)
-        cnt = self.visit(e.cnt)
-        if base is e.base and cnt is e.cnt:
+        base = self.visit(e.a)
+        cnt = self.visit(e.b)
+        if base is e.a and cnt is e.b:
             return e
         else:
             return RightShift(base, cnt)

--- a/python/hidet/ir/functors/expr_functor.py
+++ b/python/hidet/ir/functors/expr_functor.py
@@ -411,7 +411,7 @@ class ExprRewriter(ExprFunctor, BaseRewriter):
 
     def visit_TensorElement(self, e: TensorElement):
         base = self(e.base)
-        indices = [self(idx) if idx is not None else None for idx in e.indices]
+        indices = tuple(self(idx) if idx is not None else None for idx in e.indices)
         if base is e.base and same_list(indices, e.indices):
             return e
         else:
@@ -466,7 +466,7 @@ class ExprRewriter(ExprFunctor, BaseRewriter):
 
     def visit_Call(self, e: Call):
         func_var = self(e.func_var)
-        args = [self(arg) for arg in e.args]
+        args = tuple(self(arg) for arg in e.args)
         if func_var is e.func_var and same_list(args, e.args):
             return e
         else:

--- a/python/hidet/ir/functors/expr_functor.py
+++ b/python/hidet/ir/functors/expr_functor.py
@@ -14,7 +14,7 @@ from hidet.ir.expr import Add, Sub, Multiply, Div, Mod, FloorDiv, Neg, LessThan,
 from hidet.ir.expr import LogicalOr, LogicalNot, BitwiseAnd, BitwiseOr, BitwiseNot, BitwiseXor, LeftShift, RightShift
 from hidet.ir.expr import Reference, BinaryOp
 from hidet.ir.expr import TensorElement, TensorSlice, IfThenElse, Call, Let, Var, Constant, Cast, Dereference, Address
-from hidet.ir.dialects.pattern import AnyExpr
+from hidet.ir.dialects.pattern import PlaceholderExpr
 from hidet.utils import same_list
 from .base_functor import BaseFunctor, BaseVisitor, BaseRewriter
 
@@ -85,7 +85,7 @@ class ExprFunctor(BaseFunctor):
             return self.visit_Address(node)
         elif isinstance(node, Reference):
             return self.visit_Reference(node)
-        elif isinstance(node, AnyExpr):
+        elif isinstance(node, PlaceholderExpr):
             return self.visit_AnyExpr(node)
         else:
             return NotImplemented
@@ -183,7 +183,7 @@ class ExprFunctor(BaseFunctor):
     def visit_Constant(self, e: Constant):
         raise NotImplementedError()
 
-    def visit_AnyExpr(self, e: AnyExpr):
+    def visit_AnyExpr(self, e: PlaceholderExpr):
         raise NotImplementedError()
 
 
@@ -311,7 +311,7 @@ class ExprVisitor(ExprFunctor, BaseVisitor):
     def visit_Reference(self, e: Reference):
         self.visit(e.expr)
 
-    def visit_AnyExpr(self, e: AnyExpr):
+    def visit_AnyExpr(self, e: PlaceholderExpr):
         pass
 
 
@@ -487,5 +487,5 @@ class ExprRewriter(ExprFunctor, BaseRewriter):
     def visit_Constant(self, e: Constant):
         return e
 
-    def visit_AnyExpr(self, e: AnyExpr):
+    def visit_AnyExpr(self, e: PlaceholderExpr):
         return e

--- a/python/hidet/ir/functors/expr_functor.py
+++ b/python/hidet/ir/functors/expr_functor.py
@@ -12,7 +12,7 @@
 # pylint: disable=bad-staticmethod-argument
 from hidet.ir.expr import Add, Sub, Multiply, Div, Mod, FloorDiv, Neg, LessThan, LessEqual, Equal, NotEqual, LogicalAnd
 from hidet.ir.expr import LogicalOr, LogicalNot, BitwiseAnd, BitwiseOr, BitwiseNot, BitwiseXor, LeftShift, RightShift
-from hidet.ir.expr import Reference, BinaryOp
+from hidet.ir.expr import Reference, BinaryExpr
 from hidet.ir.expr import TensorElement, TensorSlice, IfThenElse, Call, Let, Var, Constant, Cast, Dereference, Address
 from hidet.ir.dialects.pattern import PlaceholderExpr
 from hidet.utils import same_list
@@ -255,7 +255,7 @@ class ExprVisitor(ExprFunctor, BaseVisitor):
         self.visit(e.b)
 
     def visit_BitwiseNot(self, e: BitwiseNot):
-        self.visit(e.base)
+        self.visit(e.a)
 
     def visit_LeftShift(self, e: LeftShift):
         self.visit(e.base)
@@ -319,7 +319,7 @@ class ExprRewriter(ExprFunctor, BaseRewriter):
     def rewrite(self, e):
         return self.visit(e)
 
-    def visit_Binary(self, e: BinaryOp):
+    def visit_Binary(self, e: BinaryExpr):
         a = self(e.a)
         b = self(e.b)
         if a is e.a and b is e.b:
@@ -387,8 +387,8 @@ class ExprRewriter(ExprFunctor, BaseRewriter):
         return self.visit_Binary(e)
 
     def visit_BitwiseNot(self, e: BitwiseNot):
-        base = self.visit(e.base)
-        if base is e.base:
+        base = self.visit(e.a)
+        if base is e.a:
             return e
         else:
             return BitwiseNot(base)

--- a/python/hidet/ir/layout.py
+++ b/python/hidet/ir/layout.py
@@ -180,9 +180,9 @@ class StridesLayout(DataLayout):
         return sum(v * self.strides[i] for i, v in enumerate(args))
 
     def global2cond(self, *args: Int) -> Bool:
-        from hidet.ir.expr import LogicalAnd
+        from hidet.ir.expr import logical_and
 
-        return LogicalAnd.join_list([v < s for s, v in zip(self.shape, args)])
+        return logical_and(*[v < s for s, v in zip(self.shape, args)])
 
     @staticmethod
     def storage_size(shape, strides) -> Expr:
@@ -228,9 +228,9 @@ class LocalLayout(DataLayout):
         return 0
 
     def global2cond(self, *args: Int) -> Bool:
-        from hidet.ir.expr import LogicalAnd
+        from hidet.ir.expr import logical_and
 
-        return LogicalAnd.join_list([v < s for s, v in zip(self.shape, args)])
+        return logical_and(*[v < s for s, v in zip(self.shape, args)])
 
 
 class SwizzleLayout(DataLayout):

--- a/python/hidet/ir/primitives/cpu/math/bfloat16.py
+++ b/python/hidet/ir/primitives/cpu/math/bfloat16.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
 from hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -45,7 +45,7 @@ class CPUBFloat16MathFunctionSet(MathFunctionSet):
 
     def call(self, name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name('cpu_bf16_{}'.format(name))
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def sin(self, a: Expr) -> Expr:
         return self.call('sin', a)

--- a/python/hidet/ir/primitives/cpu/math/float16.py
+++ b/python/hidet/ir/primitives/cpu/math/float16.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
 from hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -65,7 +65,7 @@ class CPUFloat16MathFunctionSet(MathFunctionSet):
     @staticmethod
     def call(name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name('cpu_f16_{}'.format(name))
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def sin(self, a: Expr) -> Expr:
         return self.call('sin', a)

--- a/python/hidet/ir/primitives/cpu/math/float32.py
+++ b/python/hidet/ir/primitives/cpu/math/float32.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
 from hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -66,7 +66,7 @@ class CPUFloat32MathFunctionSet(MathFunctionSet):
     @staticmethod
     def call(name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name('cpu_f32_{}'.format(name))
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def sin(self, a: Expr) -> Expr:
         return self.call('sin', a)

--- a/python/hidet/ir/primitives/cpu/math/float64.py
+++ b/python/hidet/ir/primitives/cpu/math/float64.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
 from hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -66,7 +66,7 @@ class CPUFloat64MathFunctionSet(MathFunctionSet):
     @staticmethod
     def call(name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name('cpu_f64_{}'.format(name))
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def sin(self, a: Expr) -> Expr:
         return self.call('sin', a)

--- a/python/hidet/ir/primitives/cpu/math/int32.py
+++ b/python/hidet/ir/primitives/cpu/math/int32.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
 from hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -29,7 +29,7 @@ class CPUInt32MathFunctionSet(MathFunctionSet):
 
     def call(self, name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name(name)
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def min(self, a: Expr, b: Expr) -> Expr:
         return self.call('cpu_i32_min', a, b)

--- a/python/hidet/ir/primitives/cpu/math/int64.py
+++ b/python/hidet/ir/primitives/cpu/math/int64.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
 from hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -29,7 +29,7 @@ class CPUInt64MathFunctionSet(MathFunctionSet):
 
     def call(self, name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name(name)
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def min(self, a: Expr, b: Expr) -> Expr:
         return self.call('cpu_i64_min', a, b)

--- a/python/hidet/ir/primitives/cuda/funcs.py
+++ b/python/hidet/ir/primitives/cuda/funcs.py
@@ -45,6 +45,5 @@ def register_binary_dialect_primitive_function(func_name, generic_func, target_d
 
 
 def call_cuda(func_name, args: List[Expr]) -> Call:
-    # todo: replace all usage of this function to call_primitive_func
     entry = primitive_func_pool.lookup_by_name('cuda_{}'.format(func_name))
-    return Call(entry.var, args)
+    return entry.var(*args)

--- a/python/hidet/ir/primitives/cuda/math/bfloat16.py
+++ b/python/hidet/ir/primitives/cuda/math/bfloat16.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType
 from hidet.ir.func import Function
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
@@ -58,7 +58,7 @@ class CUDABFloat16MathFunctionSet(MathFunctionSet):
 
     def call(self, name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name(name)
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def sin(self, a: Expr) -> Expr:
         return self.call('cuda_bf16_sin', a)

--- a/python/hidet/ir/primitives/cuda/math/float16.py
+++ b/python/hidet/ir/primitives/cuda/math/float16.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Callable
-from hidet.ir.expr import Expr, Call, ExprInt64, ExprFloat16, ExprInt16
+from hidet.ir.expr import Expr, ExprInt64, ExprFloat16, ExprInt16
 from hidet.ir.type import FuncType, DataType
 from hidet.ir.func import Function
 from hidet.ir.dtypes import int16, float16, float32, int64
@@ -139,7 +139,7 @@ class CUDAFloat16MathFunctionSet(MathFunctionSet):
 
     def call(self, name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name(name)
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def sin(self, a: Expr) -> Expr:
         return self.call('cuda_f16_sin', a)

--- a/python/hidet/ir/primitives/cuda/math/float32.py
+++ b/python/hidet/ir/primitives/cuda/math/float32.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
 from hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -66,7 +66,7 @@ class CUDAFloat32MathFunctionSet(MathFunctionSet):
     @staticmethod
     def call(name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name('cuda_f32_{}'.format(name))
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def sin(self, a: Expr) -> Expr:
         return self.call('sin', a)

--- a/python/hidet/ir/primitives/cuda/math/float64.py
+++ b/python/hidet/ir/primitives/cuda/math/float64.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
 from hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -66,7 +66,7 @@ class CUDAFloat64MathFunctionSet(MathFunctionSet):
     @staticmethod
     def call(name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name('cuda_f64_{}'.format(name))
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def sin(self, a: Expr) -> Expr:
         return self.call('sin', a)

--- a/python/hidet/ir/primitives/cuda/math/int32.py
+++ b/python/hidet/ir/primitives/cuda/math/int32.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
 from hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -29,7 +29,7 @@ class CUDAInt32MathFunctionSet(MathFunctionSet):
 
     def call(self, name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name(name)
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def min(self, a: Expr, b: Expr) -> Expr:
         return self.call('cuda_i32_min', a, b)

--- a/python/hidet/ir/primitives/cuda/math/int64.py
+++ b/python/hidet/ir/primitives/cuda/math/int64.py
@@ -12,7 +12,7 @@
 from typing import Optional
 
 import hidet.ir.primitives.cuda.math.float16
-from hidet.ir.expr import Expr, ExprInt64, Call
+from hidet.ir.expr import Expr, ExprInt64
 from hidet.ir.type import FuncType, DataType
 from hidet.ir.primitives.func import register_primitive_function, primitive_func_pool
 from hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -32,7 +32,7 @@ class CUDAInt64MathFunctionSet(MathFunctionSet):
 
     def call(self, name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name(name)
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     def cast(self, a: ExprInt64, cast_dtype: DataType) -> Optional[Expr]:
         if cast_dtype.name == 'float16':

--- a/python/hidet/ir/primitives/func.py
+++ b/python/hidet/ir/primitives/func.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 from typing import Dict, Union, Optional, List
 
-from hidet.ir.expr import Var, Expr, Call
+from hidet.ir.expr import Var, Expr, Call, call
 from hidet.ir.func import Function
 from hidet.ir.type import FuncType
 
@@ -147,4 +147,4 @@ def call_primitive_func(func_name, args: List[Expr]) -> Call:
                 'The number of arguments does not match the number of parameters of function {}, '
                 'got {} and expect {}.'.format(func_name, len(args), len(entry.func_type.param_types))
             )
-    return Call(entry.var, args)
+    return call(entry.var, args)

--- a/python/hidet/ir/primitives/math.py
+++ b/python/hidet/ir/primitives/math.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List, Dict, Tuple, Optional
-from hidet.ir.expr import Expr, Call
+from hidet.ir.expr import Expr
 from hidet.ir.type import FuncType, DataType, data_type
 from hidet.ir.utils.type_utils import numeric_promotion
 from hidet.ir.primitives.func import register_primitive_function, lookup_primitive_function
@@ -204,7 +204,7 @@ class MathFunctionSetGeneric(MathFunctionSet):
     @staticmethod
     def call(name, *args) -> Expr:
         entry = lookup_primitive_function(f'generic_{name}')
-        return Call(entry.var, args)
+        return entry.var(*args)
 
     # unary names
 

--- a/python/hidet/ir/tools/hasher.py
+++ b/python/hidet/ir/tools/hasher.py
@@ -12,7 +12,7 @@
 from typing import Union, Tuple, Dict
 
 from hidet.ir import Node
-from hidet.ir.dialects.pattern import AnyExpr
+from hidet.ir.dialects.pattern import PlaceholderExpr
 from hidet.ir.expr import Var, Constant, Add, Sub, Multiply, Div, Mod, FloorDiv, Neg, LessThan, LessEqual
 from hidet.ir.expr import NotEqual, Equal, IfThenElse, LogicalAnd, LogicalOr, LogicalNot, BitwiseAnd, BitwiseOr
 from hidet.ir.expr import BitwiseNot, BitwiseXor, LeftShift, RightShift
@@ -153,5 +153,5 @@ class ExprHash(ExprFunctor, TypeFunctor, BaseFunctor):
     def visit_TensorSlice(self, e: TensorSlice):
         return self(e.base) + self(e.indices) + self(e.starts) + self(e.ends) + hash(TensorSlice)
 
-    def visit_AnyExpr(self, e: AnyExpr):
-        return HashSum(e) + hash(AnyExpr)
+    def visit_AnyExpr(self, e: PlaceholderExpr):
+        return HashSum(e) + hash(PlaceholderExpr)

--- a/python/hidet/ir/tools/hasher.py
+++ b/python/hidet/ir/tools/hasher.py
@@ -100,7 +100,7 @@ class ExprHash(ExprFunctor, TypeFunctor, BaseFunctor):
         return (self(e.a) & self(e.b)) + hash(BitwiseOr)
 
     def visit_BitwiseNot(self, e: BitwiseNot):
-        return self(e.base) + hash(BitwiseNot)
+        return self(e.a) + hash(BitwiseNot)
 
     def visit_BitwiseXor(self, e: BitwiseXor):
         return (self(e.a) & self(e.b)) + hash(BitwiseXor)

--- a/python/hidet/ir/tools/hasher.py
+++ b/python/hidet/ir/tools/hasher.py
@@ -106,10 +106,10 @@ class ExprHash(ExprFunctor, TypeFunctor, BaseFunctor):
         return (self(e.a) & self(e.b)) + hash(BitwiseXor)
 
     def visit_LeftShift(self, e: LeftShift):
-        return (self(e.base) + self(e.cnt)) + hash(LeftShift)
+        return (self(e.a) + self(e.b)) + hash(LeftShift)
 
     def visit_RightShift(self, e: RightShift):
-        return (self(e.base) + self(e.cnt)) + hash(RightShift)
+        return (self(e.a) + self(e.b)) + hash(RightShift)
 
     def visit_TensorElement(self, e: TensorElement):
         return self(e.base) + self(e.indices) + hash(TensorElement)

--- a/python/hidet/ir/tools/printer.py
+++ b/python/hidet/ir/tools/printer.py
@@ -33,7 +33,7 @@ from hidet.ir.layout import StridesLayout, ConcatLayout, LocalLayout, SwizzleLay
 from hidet.ir.layout import ColumnMajorLayout
 from hidet.ir.mapping import RepeatTaskMapping, SpatialTaskMapping, ComposedTaskMapping
 from hidet.ir.compute import TensorNode, GridCompute, ArgReduceCompute, ReduceCompute, TensorInput, ScalarInput
-from hidet.ir.dialects.pattern import AnyExpr
+from hidet.ir.dialects.pattern import PlaceholderExpr
 from hidet.ir.task import Task
 from hidet.utils import same_list
 from hidet.utils.doc import Doc, NewLine, Text, doc_join
@@ -390,7 +390,7 @@ class IRPrinter(IRFunctor):
     def visit_VoidType(self, t: VoidType):
         return Text('VoidType')
 
-    def visit_AnyExpr(self, e: AnyExpr):
+    def visit_AnyExpr(self, e: PlaceholderExpr):
         return Text('AnyExpr')
 
     def print_tensor_nodes(self, nodes: List[TensorNode], exclude_nodes: List[TensorNode] = None) -> Doc:

--- a/python/hidet/ir/tools/printer.py
+++ b/python/hidet/ir/tools/printer.py
@@ -152,7 +152,7 @@ class IRPrinter(IRFunctor):
         return '(' + self(e.a) + ' ^ ' + self(e.b) + ')'
 
     def visit_BitwiseNot(self, e: BitwiseNot):
-        return '(~' + self(e.base) + ')'
+        return '(~' + self(e.a) + ')'
 
     def visit_LeftShift(self, e: LeftShift):
         return '(' + self(e.base) + ' << ' + self(e.cnt) + ')'

--- a/python/hidet/ir/tools/printer.py
+++ b/python/hidet/ir/tools/printer.py
@@ -155,10 +155,10 @@ class IRPrinter(IRFunctor):
         return '(~' + self(e.a) + ')'
 
     def visit_LeftShift(self, e: LeftShift):
-        return '(' + self(e.base) + ' << ' + self(e.cnt) + ')'
+        return '(' + self(e.a) + ' << ' + self(e.b) + ')'
 
     def visit_RightShift(self, e: RightShift):
-        return '(' + self(e.base) + ' >> ' + self(e.cnt) + ')'
+        return '(' + self(e.a) + ' >> ' + self(e.b) + ')'
 
     def visit_TensorElement(self, e: TensorElement):
         if e.protected:

--- a/python/hidet/ir/tools/simplifier.py
+++ b/python/hidet/ir/tools/simplifier.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 from typing import Union
 import operator
-from hidet.ir.expr import Expr, BinaryOp, Add, Sub, Multiply, Div, Mod, FloorDiv, LessThan, LessEqual, Equal, Constant
+from hidet.ir.expr import Expr, BinaryExpr, Add, Sub, Multiply, Div, Mod, FloorDiv, LessThan, LessEqual, Equal, Constant
 from hidet.ir.expr import BitwiseAnd, BitwiseOr, BitwiseXor
 from hidet.ir.expr import LogicalAnd, LogicalOr, LogicalNot, is_one, is_zero, is_true, is_false, convert
 from hidet.ir.stmt import Stmt, IfStmt, SeqStmt, ForStmt
@@ -20,7 +20,7 @@ from hidet.ir.functors import StmtRewriter, ExprRewriter, BaseRewriter
 
 
 class Simplifier(StmtRewriter, ExprRewriter, BaseRewriter):
-    def visit_Binary(self, e: BinaryOp):  # pylint: disable=too-many-branches
+    def visit_Binary(self, e: BinaryExpr):  # pylint: disable=too-many-branches
         a = self(e.a)
         b = self(e.b)
         if isinstance(e, Add):

--- a/python/hidet/ir/tools/type_infer.py
+++ b/python/hidet/ir/tools/type_infer.py
@@ -17,7 +17,7 @@ from hidet.ir.expr import BitwiseAnd, Neg, NotEqual, BitwiseXor, Dereference, Re
 from hidet.ir.expr import Var, Constant, TensorElement, Call, Cast
 from hidet.ir.compute import ArgReduceCompute, ReduceCompute, GridCompute, TensorInput, ScalarInput
 from hidet.ir.functors import ExprFunctor, ComputeFunctor
-from hidet.ir.dialects.pattern import AnyExpr
+from hidet.ir.dialects.pattern import PlaceholderExpr
 
 
 def is_bool(tp: DataType):
@@ -203,7 +203,7 @@ class TypeInfer(ExprFunctor, ComputeFunctor):
     def visit_ArgReduceCompute(self, c: ArgReduceCompute):
         return c.index_dtype
 
-    def visit_AnyExpr(self, e: AnyExpr):
+    def visit_AnyExpr(self, e: PlaceholderExpr):
         raise NotImplementedError()
 
 

--- a/python/hidet/ir/tools/type_infer.py
+++ b/python/hidet/ir/tools/type_infer.py
@@ -101,10 +101,10 @@ class TypeInfer(ExprFunctor, ComputeFunctor):
         return self.visit(e.a)
 
     def visit_LeftShift(self, e: LeftShift):
-        return self.visit(e.base)
+        return self.visit(e.a)
 
     def visit_RightShift(self, e: RightShift):
-        return self.visit(e.base)
+        return self.visit(e.a)
 
     def visit_TensorElement(self, e: TensorElement):
         base_type = self.visit(e.base)

--- a/python/hidet/ir/tools/type_infer.py
+++ b/python/hidet/ir/tools/type_infer.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 from hidet.ir.type import DataType, TensorType, FuncType, PointerType, TensorPointerType, data_type, tensor_pointer_type
 from hidet.ir.type import tensor_type
-from hidet.ir.expr import BinaryOp, Add, Sub, Multiply, Div, Mod, FloorDiv, Condition, LessThan, Equal, IfThenElse
+from hidet.ir.expr import BinaryExpr, Add, Sub, Multiply, Div, Mod, FloorDiv, Condition, LessThan, Equal, IfThenElse
 from hidet.ir.expr import TensorSlice, LogicalNot, LogicalOr, LogicalAnd, LessEqual, Let, RightShift, LeftShift
 from hidet.ir.expr import BitwiseAnd, Neg, NotEqual, BitwiseXor, Dereference, Reference, Address, BitwiseNot, BitwiseOr
 from hidet.ir.expr import Var, Constant, TensorElement, Call, Cast
@@ -32,7 +32,7 @@ class TypeInfer(ExprFunctor, ComputeFunctor):
     def visit_Reference(self, e: Reference):
         return self(e.expr)
 
-    def visit_Binary(self, e: BinaryOp):
+    def visit_Binary(self, e: BinaryExpr):
         from hidet.ir.utils.type_utils import numeric_promotion
 
         a_dtype: DataType = self.visit(e.a)
@@ -98,7 +98,7 @@ class TypeInfer(ExprFunctor, ComputeFunctor):
         return self.visit(e.a)
 
     def visit_BitwiseNot(self, e: BitwiseNot):
-        return self.visit(e.base)
+        return self.visit(e.a)
 
     def visit_LeftShift(self, e: LeftShift):
         return self.visit(e.base)

--- a/python/hidet/ir/type.py
+++ b/python/hidet/ir/type.py
@@ -44,6 +44,9 @@ class TypeNode(Node):
     def is_data_type(self):
         return isinstance(self, DataType)
 
+    def is_func_type(self):
+        return isinstance(self, FuncType)
+
 
 class DataType(TypeNode):
     """

--- a/python/hidet/transforms/add_explicit_cast.py
+++ b/python/hidet/transforms/add_explicit_cast.py
@@ -12,7 +12,7 @@
 from hidet.ir.functors import IRRewriter
 from hidet.ir.tools import TypeInfer
 from hidet.ir.stmt import Stmt, AssignStmt, BufferStoreStmt
-from hidet.ir.expr import Expr, Cast, Add, Sub, Multiply, Div, BinaryOp, cast
+from hidet.ir.expr import Expr, Cast, Add, Sub, Multiply, Div, BinaryExpr, cast
 from hidet.ir.type import DataType, TypeNode, TensorType, TensorPointerType, PointerType, ReferenceType, VoidType
 from .base import FunctionBodyPass, Pass
 
@@ -104,7 +104,7 @@ class AddExplicitCastRewriter(IRRewriter):
         else:
             return cast(source_value, target_type)
 
-    def visit_Binary(self, e: BinaryOp):
+    def visit_Binary(self, e: BinaryExpr):
         if isinstance(e, (Add, Sub, Multiply, Div)):
             from hidet.ir.utils.type_utils import numeric_promotion
 

--- a/python/hidet/transforms/common/scope.py
+++ b/python/hidet/transforms/common/scope.py
@@ -12,7 +12,7 @@
 from typing import List, Dict, Optional, ContextManager
 
 from hidet.ir.type import FuncType, data_type
-from hidet.ir.expr import Expr, Var, BitwiseAnd, LeftShift, BitwiseOr
+from hidet.ir.expr import Expr, Var, BitwiseAnd, bitwise_or, left_shift
 from hidet.ir.tools import collect
 from hidet.ir.stmt import LetStmt, ForStmt
 from hidet.ir.func import Function
@@ -77,7 +77,7 @@ class Scope:
         bind_values = [self.var2value[var] for var in bind_vars]
         for p_var, p_exprs in zip(self.predicate_vars, self.defined_predicates):
             bind_vars.append(p_var)
-            bind_values.append(BitwiseOr.join_list([LeftShift(p, idx) for idx, p in enumerate(p_exprs)]))
+            bind_values.append(bitwise_or(*[left_shift(p, idx) for idx, p in enumerate(p_exprs)]))
         if len(bind_vars) > 0:
             ret = LetStmt(bind_vars, bind_values, body)
         else:

--- a/python/hidet/transforms/flatten_tensor_index.py
+++ b/python/hidet/transforms/flatten_tensor_index.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from hidet.ir.type import TensorType, tensor_type, tensor_pointer_type, PointerType, TensorPointerType
-from hidet.ir.expr import Var, TensorElement, TensorSlice, Constant
+from hidet.ir.expr import Var, TensorElement, TensorSlice, Constant, tensor_element
 from hidet.ir.stmt import BufferStoreStmt, DeclareStmt
 from hidet.ir.func import Function
 from hidet.ir.functors import IRRewriter
@@ -72,7 +72,7 @@ class FlattenTensorAccessRewriter(IRRewriter):
                 )
             )
         global_index = layout(*indices)
-        return TensorElement(var, [global_index])
+        return tensor_element(var, (global_index,))
 
     def visit_BufferStoreStmt(self, stmt: BufferStoreStmt):
         var = self(stmt.buf)

--- a/python/hidet/transforms/flatten_tensor_slice.py
+++ b/python/hidet/transforms/flatten_tensor_slice.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # pylint: disable=unused-variable
-from hidet.ir.expr import TensorElement, TensorSlice
+from hidet.ir.expr import TensorElement, TensorSlice, tensor_element, tensor_slice
 from hidet.ir.func import Function
 from hidet.ir.functors import IRRewriter
 from hidet.ir.stmt import BufferStoreStmt
@@ -64,7 +64,7 @@ class FlattenTensorSliceRewriter(IRRewriter):
             e_starts = [self.visit(s) if s is not None else None for s in e.starts]
             e_ends = [self.visit(e) if e is not None else None for e in e.ends]
             indices, starts, ends = concat_slices(base.indices, base.starts, base.ends, e_indices, e_starts, e_ends)
-            return TensorSlice(base.base, indices, starts, ends)
+            return tensor_slice(base.base, indices, starts, ends)
         else:
             return IRRewriter.visit_TensorSlice(self, e)
 
@@ -74,7 +74,7 @@ class FlattenTensorSliceRewriter(IRRewriter):
             e_indices = [self.visit(idx) for idx in e.indices]
             indices, starts, ends = concat_slices(base.indices, base.starts, base.ends, e_indices)
             assert not any(idx is None for idx in indices)
-            return TensorElement(base.base, indices, e.protected)
+            return tensor_element(base.base, indices, e.protected)
         else:
             return IRRewriter.visit_TensorElement(self, e)
 

--- a/python/hidet/transforms/generate_packed_func.py
+++ b/python/hidet/transforms/generate_packed_func.py
@@ -14,7 +14,7 @@ from hidet.ffi.packedfunc import ArgTypeCode
 from hidet.ir.func import Function, IRModule
 from hidet.ir.type import DataType, TensorType, TensorPointerType, PointerType
 from hidet.ir.dtypes import int32
-from hidet.ir.expr import Expr, Var, Call, Constant
+from hidet.ir.expr import Expr, Var, Constant
 from hidet.ir.stmt import Stmt, AssertStmt, LaunchKernelStmt, DeclareStmt
 from hidet.ir.tools import rewrite, simplify
 from hidet.ir.builders import StmtBuilder
@@ -97,7 +97,7 @@ def add_packed_func(ir_module: IRModule, func: Function, pack_func_name: str):
                 shared_mem=smem_bytes,
             )
         elif func.kind == 'host_kernel':
-            sb += Call(func_var, [param2arg[param] for param in func.params])
+            sb += func_var(*[param2arg[param] for param in func.params])
         else:
             raise NotImplementedError('Unsupported function kind: {}'.format(func.kind))
         return sb.finish()

--- a/python/hidet/transforms/resolve_generic_primitive_function.py
+++ b/python/hidet/transforms/resolve_generic_primitive_function.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Tuple
 
 from hidet.ir.type import DataType
 from hidet.ir.stmt import Stmt
-from hidet.ir.expr import Call, Expr, BinaryOp, cast
+from hidet.ir.expr import Call, Expr, BinaryExpr, cast
 from hidet.ir.func import Function
 from hidet.ir.functors import IRRewriter
 from hidet.ir.tools import infer_type, TypeInfer
@@ -76,7 +76,7 @@ class ResolveGenericPrimitiveFuncRewriter(IRRewriter):
 
         return IRRewriter.visit_Call(self, e)
 
-    def visit_Binary(self, e: BinaryOp):
+    def visit_Binary(self, e: BinaryExpr):
         lhs = self.visit(e.a)
         rhs = self.visit(e.b)
         lhs_dtype = self.type_infer(lhs)

--- a/python/hidet/transforms/rule_based_simplifier.py
+++ b/python/hidet/transforms/rule_based_simplifier.py
@@ -14,7 +14,19 @@ from typing import Dict
 from itertools import product
 
 from hidet.ir.dialects.pattern import PlaceholderExpr, match
-from hidet.ir.expr import Add, convert, Sub, Multiply, Mod, LessThan, LessEqual, Equal, BinaryOp, LogicalAnd, IfThenElse
+from hidet.ir.expr import (
+    Add,
+    convert,
+    Sub,
+    Multiply,
+    Mod,
+    LessThan,
+    LessEqual,
+    Equal,
+    BinaryExpr,
+    LogicalAnd,
+    IfThenElse,
+)
 from hidet.ir.expr import LogicalOr, BitwiseXor, BitwiseAnd, BitwiseOr, BitwiseNot
 from hidet.ir.expr import Div, Constant, Expr
 from hidet.ir.functors import IRRewriter
@@ -56,7 +68,7 @@ class ConstExprSimplifier(IRRewriter):
         Equal: operator.eq,
     }
 
-    def visit_Binary(self, e: BinaryOp):
+    def visit_Binary(self, e: BinaryExpr):
         from hidet.ir.utils.type_utils import numeric_promotion
 
         e = IRRewriter.visit_Binary(self, e)

--- a/python/hidet/transforms/rule_based_simplifier.py
+++ b/python/hidet/transforms/rule_based_simplifier.py
@@ -14,6 +14,7 @@ from typing import Dict
 from itertools import product
 
 from hidet.ir.dialects.pattern import PlaceholderExpr, match
+from hidet.ir.dtypes import boolean
 from hidet.ir.expr import (
     Add,
     convert,
@@ -26,6 +27,7 @@ from hidet.ir.expr import (
     BinaryExpr,
     LogicalAnd,
     IfThenElse,
+    if_then_else
 )
 from hidet.ir.expr import LogicalOr, BitwiseXor, BitwiseAnd, BitwiseOr, BitwiseNot
 from hidet.ir.expr import Div, Constant, Expr
@@ -152,12 +154,12 @@ class RuleBasedSimplifier(IRRewriter):
             (c1 <= e1 + c2, c1 - c2 <= e1),
             # and/or
             (LogicalAnd(ec1, True), ec1),
-            (LogicalAnd(ec1, False), convert(False)),
-            (LogicalOr(ec1, True), convert(True)),
+            (LogicalAnd(ec1, False), boolean.false),
+            (LogicalOr(ec1, True), boolean.true),
             (LogicalOr(ec1, False), ec1),
             # if then else
-            (IfThenElse(True, ec1, ec2), ec1),
-            (IfThenElse(False, ec1, ec2), ec2),
+            (if_then_else(True, ec1, ec2), ec1),
+            (if_then_else(True, ec1, ec2), ec2),
         ]
         self.bound_patterns = [
             # ((pattern_args, pattern_func, target_args, target_func)

--- a/python/hidet/transforms/rule_based_simplifier.py
+++ b/python/hidet/transforms/rule_based_simplifier.py
@@ -15,22 +15,9 @@ from itertools import product
 
 from hidet.ir.dialects.pattern import PlaceholderExpr, match
 from hidet.ir.dtypes import boolean
-from hidet.ir.expr import (
-    Add,
-    convert,
-    Sub,
-    Multiply,
-    Mod,
-    LessThan,
-    LessEqual,
-    Equal,
-    BinaryExpr,
-    LogicalAnd,
-    IfThenElse,
-    if_then_else
-)
-from hidet.ir.expr import LogicalOr, BitwiseXor, BitwiseAnd, BitwiseOr, BitwiseNot
-from hidet.ir.expr import Div, Constant, Expr
+from hidet.ir.expr import Add, convert, Sub, Multiply, Mod, LessThan, LessEqual, Equal, BinaryExpr, LogicalAnd
+from hidet.ir.expr import BitwiseXor, BitwiseAnd, BitwiseOr, BitwiseNot
+from hidet.ir.expr import Div, Constant, Expr, logical_and, logical_or, if_then_else
 from hidet.ir.functors import IRRewriter
 from hidet.ir.tools import rewrite
 from hidet.transforms.base import FunctionPass
@@ -74,10 +61,10 @@ class ConstExprSimplifier(IRRewriter):
         from hidet.ir.utils.type_utils import numeric_promotion
 
         e = IRRewriter.visit_Binary(self, e)
-        if e.a.is_const() and e.b.is_const() and e.__class__ in self.op_dict:
+        if isinstance(e.a, Constant) and isinstance(e.b, Constant) and e.__class__ in self.op_dict:
             assert isinstance(e.a, Constant) and isinstance(e.b, Constant)
             op = self.op_dict[e.__class__]
-            c = op(e.a.const().value, e.b.const().value)
+            c = op(e.a.value, e.b.value)
             if isinstance(c, bool):
                 return Constant(c, 'bool')
             else:
@@ -86,8 +73,8 @@ class ConstExprSimplifier(IRRewriter):
 
     def visit_And(self, e: LogicalAnd):
         e = IRRewriter.visit_Binary(self, e)
-        a_val = e.a.const().value if e.a.is_const() else None
-        b_val = e.b.const().value if e.b.is_const() else None
+        a_val = e.a.value if isinstance(e.a, Constant) else None
+        b_val = e.b.value if isinstance(e.b, Constant) else None
         if a_val and b_val:
             return convert(True)
         elif a_val is False or b_val is False:
@@ -153,10 +140,10 @@ class RuleBasedSimplifier(IRRewriter):
             (c1 <= e1 - c2, c1 + c2 <= e1),
             (c1 <= e1 + c2, c1 - c2 <= e1),
             # and/or
-            (LogicalAnd(ec1, True), ec1),
-            (LogicalAnd(ec1, False), boolean.false),
-            (LogicalOr(ec1, True), boolean.true),
-            (LogicalOr(ec1, False), ec1),
+            (logical_and(ec1, True), ec1),
+            (logical_and(ec1, False), boolean.false),
+            (logical_or(ec1, True), boolean.true),
+            (logical_or(ec1, False), ec1),
             # if then else
             (if_then_else(True, ec1, ec2), ec1),
             (if_then_else(True, ec1, ec2), ec2),

--- a/python/hidet/transforms/rule_based_simplifier.py
+++ b/python/hidet/transforms/rule_based_simplifier.py
@@ -13,7 +13,7 @@ import operator
 from typing import Dict
 from itertools import product
 
-from hidet.ir.dialects.pattern import AnyExpr, match
+from hidet.ir.dialects.pattern import PlaceholderExpr, match
 from hidet.ir.expr import Add, convert, Sub, Multiply, Mod, LessThan, LessEqual, Equal, BinaryOp, LogicalAnd, IfThenElse
 from hidet.ir.expr import LogicalOr, BitwiseXor, BitwiseAnd, BitwiseOr, BitwiseNot
 from hidet.ir.expr import Div, Constant, Expr
@@ -26,14 +26,11 @@ from hidet.ir.analyzers import BoundAnalyzer, BoundInfo
 
 
 def any_expr(allow_const):
-    if allow_const:
-        return AnyExpr()
-    else:
-        return AnyExpr(exclude_cls=Constant)
+    return PlaceholderExpr(require_non_const=not allow_const)
 
 
 def any_constant():
-    return Constant(value=None)
+    return PlaceholderExpr(require_const=True)
 
 
 def c_div(a, b):

--- a/tests/ir/dialects/test_pattern.py
+++ b/tests/ir/dialects/test_pattern.py
@@ -10,9 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
-from hidet.ir.expr import *
-from hidet.ir.compute import compute
-from hidet.ir.dialects.pattern import match, AnyExpr, UnionPattern, any_const_int
+from hidet.ir.expr import var, Add
+from hidet.ir.dialects.pattern import match, PlaceholderExpr
 
 
 def check_pairs(pairs):
@@ -27,7 +26,8 @@ def check_pairs(pairs):
 
 
 def test_normal_expr():
-    a, b, c, d = var('a'), var('b'), var('c'), var('d')
+    a, b = PlaceholderExpr(), PlaceholderExpr()
+    c, d = var('c'), var('d')
 
     pairs = [
         (Add(a, b), Add(c, d), {a: c, b: d}),
@@ -39,35 +39,12 @@ def test_normal_expr():
 
 
 def test_any_pattern():
-    a, b, c, d = var('a'), var('b'), var('c'), var('d')
+    a, c, d = var('a'), var('c'), var('d')
+    b = PlaceholderExpr()
     s = Add(a, b)
-    m = Multiply(a, b)
-    any_expr = AnyExpr()
-    any_var = AnyExpr(Var)
-    any_add = AnyExpr(Add)
+    any_expr = PlaceholderExpr()
 
-    pairs = [
-        (any_expr, s, {any_expr: s}),
-        (Add(any_expr, b), Add(c, d), {any_expr: c, b: d}),
-        (any_var, Add(c, d), None),
-        (any_add, s, {any_add: s}),
-        (any_add, m, None),
-    ]
-    check_pairs(pairs)
-
-
-def test_union_pattern():
-    a, b, c, d = var('a'), var('b'), var('c'), var('d')
-    add_cd = Add(c, d)
-    mul_cd = Multiply(c, d)
-    union = UnionPattern([Add(a, b), Multiply(a, b), a])
-
-    pairs = [
-        (union, c, {union: c, a: c}),
-        (union, add_cd, {union: add_cd, a: c, b: d}),
-        (union, mul_cd, {union: mul_cd, a: c, b: d}),
-        (union, Mod(c, d), None),
-    ]
+    pairs = [(any_expr, s, {any_expr: s}), (Add(any_expr, b), Add(c, d), {any_expr: c, b: d})]
     check_pairs(pairs)
 
 

--- a/tests/ir/test_expr_const_fold.py
+++ b/tests/ir/test_expr_const_fold.py
@@ -1,0 +1,68 @@
+import pytest
+import operator
+import hidet
+from hidet import int32, boolean, float16, float32, int8, uint16
+from hidet.ir.expr import Constant
+
+
+def check(a: Constant, b: Constant):
+    assert isinstance(a, Constant)
+    assert isinstance(b, Constant)
+    assert a.type == b.type
+    assert a.value == b.value
+
+
+@pytest.mark.parametrize(
+    'op, result',
+    [
+        # arithmetic
+        [operator.add, int32(8)],
+        [operator.sub, int32(2)],
+        [operator.mul, int32(15)],
+        [operator.truediv, int32(1)],  # hidet treat a / b and a // b as the same semantics as C language
+        [operator.floordiv, int32(1)],
+        [operator.mod, int32(2)],
+        # comparison
+        [operator.le, boolean(False)],
+        [operator.lt, boolean(False)],
+        [operator.ge, boolean(True)],
+        [operator.gt, boolean(True)],
+        [operator.eq, boolean(False)],
+        [operator.ne, boolean(True)],
+        # bitwise
+        [operator.and_, int32(5 & 3)],
+        [operator.or_, int32(5 | 3)],
+        [operator.xor, int32(5 ^ 3)],
+        [operator.lshift, int32(5 << 3)],
+        [operator.rshift, int32(5 >> 3)],
+    ],
+)
+def test_arithmetic_binary_op(op, result):
+    a = hidet.ir.dtypes.int32(5)
+    b = hidet.ir.dtypes.int32(3)
+    check(op(a, b), result)
+
+
+@pytest.mark.parametrize('op, result', [[operator.neg, int32(-5)]])
+def test_arithmetic_unary_op(op, result):
+    a = hidet.ir.dtypes.int32(5)
+    check(op(a), result)
+
+
+def test_expr_const_fold():
+    a = int32(1)
+    b = float32(2.0)
+    c = float16(3.0)
+    d = int8(4)
+    e = uint16(5)
+
+    check(a + b, float32(3.0))
+    check(a + c, float16(4.0))
+    check(a + d, int32(5))
+    check(a + e, int32(6))
+    check(b + c, float32(5.0))
+    check(b + d, float32(6.0))
+    check(b + e, float32(7.0))
+    check(c + d, float16(7.0))
+    check(c + e, float16(8.0))
+    check(d + e, int32(9))


### PR DESCRIPTION
Previously, when we do some arhtimatic operations for constant, we will keep them in our IR:
```python
from hidet.ir.expr import convert
a = convert(1)
b = convert(2)
c = a + b
print(c)  # would be Add(Constant(1), Constant(2))
```
With this PR, we will do the computation when we create the Add expression, and replace it with hidet.ir.Constant:
```python
from hidet.ir.expr import convert
a = convert(1)
b = convert(2)
c = a + b
print(c)  # would be Constant(3)
```

This PR also clean the `hidet.ir.dialects.pattern.py`. We do not many fancy pattern matching any more.