### PR TITLE
[Cache] Add cache management command line interface

### DIFF
--- a/python/hidet/cli/bench/bench.py
+++ b/python/hidet/cli/bench/bench.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 from typing import Optional
 import click
-import torch
 import hidet
 from hidet.utils import initialize
 from . import vision
@@ -61,7 +60,7 @@ from .bench_all import bench_all
     type=click.Path(dir_okay=True, file_okay=False, writable=True),
     help='The cache directory to store the generated kernels.',
 )
-def bench_group(
+def hidet_bench_group(
     space: str,
     dtype: str,
     tensor_core: bool,
@@ -70,6 +69,8 @@ def bench_group(
     enable_torch_cublas_tf32: bool,
     cache_dir: Optional[click.Path],
 ):
+    import torch
+
     BenchModel.search_space = int(space)
     BenchModel.dtype = getattr(torch, dtype)
     BenchModel.tensor_core = tensor_core
@@ -92,4 +93,4 @@ def register_commands():
         nlp.bench_nlp,
     ]:
         assert isinstance(command, click.Command)
-        bench_group.add_command(command)
+        hidet_bench_group.add_command(command)

--- a/python/hidet/cli/bench/model.py
+++ b/python/hidet/cli/bench/model.py
@@ -12,14 +12,13 @@
 # pylint: disable=ungrouped-imports, no-name-in-module
 from typing import List, Any, Optional
 import click
-import torch
 from hidet.testing import benchmark_func
 import hidet
 
 
 class BenchModel:
     search_space = 0
-    dtype: torch.dtype = torch.float32
+    dtype = None  # torch.float32
     tensor_core: bool = False
     disable_torch_cudnn_tf32 = False
     enable_torch_cublas_tf32 = False
@@ -51,12 +50,18 @@ class BenchModel:
         raise NotImplementedError()
 
     def converted_model(self):
+        import torch
+
+        if BenchModel.dtype is None:
+            BenchModel.dtype = torch.float32
         model = self.model().eval()
         model = model.to(dtype=BenchModel.dtype)
         model = model.cuda()
         return model
 
     def converted_inputs(self):
+        import torch
+
         args, kwargs = self.example_inputs()
 
         def convert_f32(arg):

--- a/python/hidet/cli/bench/nlp/nlp_model.py
+++ b/python/hidet/cli/bench/nlp/nlp_model.py
@@ -9,7 +9,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import torch
 from hidet.cli.bench.model import BenchModel
 
 
@@ -25,9 +24,13 @@ class NLPModel(BenchModel):
         return '{}/{}'.format(self.model_name, self.label)
 
     def model(self):
+        import torch
+
         return torch.hub.load(self.repo_name, self.model_name, self.label)
 
     def example_inputs(self):
+        import torch
+
         tokens_tensor = torch.zeros((self.batch_size, self.sequence_length), dtype=torch.long, device='cuda')
         segments_tensors = torch.zeros((self.batch_size, self.sequence_length), dtype=torch.long, device='cuda')
         args = (tokens_tensor,)
@@ -35,6 +38,8 @@ class NLPModel(BenchModel):
         return args, kwargs
 
     def inputs_str(self) -> str:
+        import torch
+
         if self.dtype == torch.float16:
             dtype = 'f16'
         elif self.dtype == torch.float32:

--- a/python/hidet/cli/cache/__init__.py
+++ b/python/hidet/cli/cache/__init__.py
@@ -9,11 +9,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.graph.frontend.torch import availability as torch_availability
-from .bench import hidet_bench_group
-
-if not torch_availability.dynamo_available():
-    raise RuntimeError(
-        'PyTorch version is less than 2.0. Please upgrade PyTorch to 2.0 or higher to enable torch dynamo'
-        'which is required by the benchmark scripts.'
-    )
+from .entry import hidet_cache_group

--- a/python/hidet/cli/cache/clear.py
+++ b/python/hidet/cli/cache/clear.py
@@ -1,0 +1,35 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import shutil
+import click
+import hidet
+from .utils import get_size, nbytes2str
+
+
+@click.command(name='clear', help='Clear the hidet cache.')
+@click.option('--all', is_flag=True, default=False, help='Clear all the cache.')
+def hidet_cache_clear(all: bool):
+    if all:
+        cache_dir: str = hidet.option.get_cache_dir()
+        print('Clearing hidet cache: {}'.format(cache_dir))
+        freed_space: int = get_size(cache_dir)
+        if os.path.exists(cache_dir):
+            shutil.rmtree(cache_dir, ignore_errors=True)
+    else:
+        op_cache_dir: str = os.path.join(hidet.option.get_cache_dir(), 'ops')
+        print('Clearing hidet ops cache: {}'.format(op_cache_dir))
+        freed_space: int = get_size(op_cache_dir)
+        if os.path.exists(op_cache_dir):
+            shutil.rmtree(op_cache_dir, ignore_errors=True)
+
+    print('Freed space: {}'.format(nbytes2str(freed_space)))

--- a/python/hidet/cli/cache/entry.py
+++ b/python/hidet/cli/cache/entry.py
@@ -9,11 +9,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from hidet.graph.frontend.torch import availability as torch_availability
-from .bench import hidet_bench_group
+import click
+from .status import hidet_cache_status
+from .clear import hidet_cache_clear
 
-if not torch_availability.dynamo_available():
-    raise RuntimeError(
-        'PyTorch version is less than 2.0. Please upgrade PyTorch to 2.0 or higher to enable torch dynamo'
-        'which is required by the benchmark scripts.'
-    )
+
+@click.group(name='cache', help='Manage hidet cache.')
+def hidet_cache_group():
+    pass
+
+
+for command in [hidet_cache_status, hidet_cache_clear]:
+    assert isinstance(command, click.Command)
+    hidet_cache_group.add_command(command)

--- a/python/hidet/cli/cache/status.py
+++ b/python/hidet/cli/cache/status.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from tabulate import tabulate
+import click
+import hidet
+from .utils import nbytes2str, get_size
+
+
+@click.command(name='status', help='Show cache status.')
+def hidet_cache_status():
+    cache_dir: str = hidet.option.get_cache_dir()
+    if not os.path.exists(cache_dir):
+        print('Cache directory does not exist: {}'.format(cache_dir))
+        return
+    table = []
+    print('Hidet cache directory: {}'.format(cache_dir))
+    for entry in os.scandir(cache_dir):
+        relpath = os.path.relpath(entry.path, cache_dir)
+        if entry.is_dir():
+            relpath += '/'
+        table.append([relpath, get_size(entry.path)])
+    table.sort(key=lambda x: x[1], reverse=True)
+    table = [[a, nbytes2str(b)] for a, b in table]
+    print(tabulate(table, headers=['Path', 'Size'], colalign=('right', 'right')))

--- a/python/hidet/cli/cache/utils.py
+++ b/python/hidet/cli/cache/utils.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+
+def get_size(path: str) -> int:
+    if not os.path.exists(path):
+        return 0
+    if os.path.isfile(path):
+        return os.path.getsize(path)
+    size = 0
+    for entry in os.scandir(path):
+        size += get_size(entry.path)
+    return size
+
+
+def nbytes2str(nbytes: int) -> str:
+    for uint in ['B', 'KiB', 'MiB', 'GiB', 'TiB']:
+        if nbytes < 128:
+            if isinstance(nbytes, int):
+                return '{} {}'.format(nbytes, uint)
+            else:
+                return '{:.2f} {}'.format(nbytes, uint)
+        nbytes /= 1024
+    return '{:.2f} PiB'.format(nbytes)

--- a/python/hidet/cli/main.py
+++ b/python/hidet/cli/main.py
@@ -10,7 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import click
-from hidet.cli.bench import bench_group
+from hidet.cli.bench import hidet_bench_group
+from hidet.cli.cache import hidet_cache_group
 from hidet.utils import initialize
 
 
@@ -21,7 +22,7 @@ def main():
 
 @initialize()
 def register_commands():
-    for group in [bench_group]:
+    for group in [hidet_bench_group, hidet_cache_group]:
         assert isinstance(group, click.Command)
         main.add_command(group)
 

--- a/python/hidet/driver.py
+++ b/python/hidet/driver.py
@@ -73,9 +73,17 @@ def build_task(task: Task, target_device='cuda', load=True) -> Optional[Compiled
         else:
             src_path = os.path.join(task_dir, 'source.cpp')
         lib_path = os.path.join(task_dir, 'lib.so')
+        version_path = os.path.join(task_dir, 'version.txt')
+
+        version_matched = False
+        if os.path.exists(version_path):
+            with open(version_path, 'r') as f:
+                version = f.read()
+                if version.strip() == hidet.__version__:
+                    version_matched = True
 
         # use previously generated library when available
-        if use_cache and os.path.exists(lib_path):
+        if use_cache and os.path.exists(lib_path) and version_matched:
             logger.debug(f"Load cached task binary {green(task.name)} from path: \n{cyan(lib_path)}")
             if load:
                 compiled_func = load_task_func(lib_path, task)
@@ -87,6 +95,9 @@ def build_task(task: Task, target_device='cuda', load=True) -> Optional[Compiled
             # write task
             with open(os.path.join(task_dir, 'task.txt'), 'w') as f:
                 f.write(task_string)
+            # write version
+            with open(version_path, 'w') as f:
+                f.write(hidet.__version__)
             # implement task
             ir_module = task.implement(target=target_device, working_dir=task_dir)
             # lower ir module


### PR DESCRIPTION
## Add `version.txt` in operator cache
Now, we only use the compiled `lib.so` in the operator cache when the `version.txt` matches the current hidet version. Otherwise, we would re-compile the operator.

## Add `hidet cache` commands
```console
$ hidet cache
Usage: hidet cache [OPTIONS] COMMAND [ARGS]...

  Manage hidet cache.

Options:
  --help  Show this message and exit.

Commands:
  clear   Clear the hidet cache.
  status  Show cache status.

$ hidet cache clear --help
Usage: hidet cache clear [OPTIONS]

  Clear the hidet cache.

Options:
  --all   Clear all the cache.
  --help  Show this message and exit.

$ hidet cache status 
Hidet cache directory: /home/user/repos/hidet/.hidet_cache
       Path       Size
-----------  ---------
  examples/   1.07 GiB
test_cache/   0.55 GiB
    ops.zip   0.53 GiB
      onnx/   0.50 GiB
trt_engine/  54.40 MiB
docs-cache/  12.34 MiB
 benchmark/   2.23 MiB
```