### PR TITLE
fix batch_matmul for invalid mma config for sm  < 80

### DIFF
--- a/python/hidet/graph/frontend/torch/dynamo_backends.py
+++ b/python/hidet/graph/frontend/torch/dynamo_backends.py
@@ -19,6 +19,7 @@ from hidet.graph.ir.flow_graph import FlowGraph
 from hidet.graph.transforms import PassContext, optimize
 from .utils import serialize_output, deserialize_output, resolve_save_dir_multigraph
 from .dynamo_config import dynamo_config
+from .interpreter import warnings
 
 
 logger = logging.getLogger(__name__)
@@ -63,7 +64,7 @@ def generate_executor(flow_graph: FlowGraph) -> Callable:
         torch_inputs: List[torch.Tensor] = []
         for x in inputs:
             if not x.is_contiguous():
-                logger.warning('Hidet received a non-contiguous torch input tensor, converting it to contiguous')
+                warnings.warn_once('Hidet received a non-contiguous torch input tensor, converting it to contiguous')
                 x = x.contiguous()
             torch_inputs.append(x)
         hidet_inputs: List[hidet.Tensor] = [hidet.from_torch(tensor) for tensor in torch_inputs]

--- a/python/hidet/ir/primitives/cuda/mma.py
+++ b/python/hidet/ir/primitives/cuda/mma.py
@@ -226,7 +226,7 @@ def filter_mma_by_cc(compute_capability):
     for config_name, config in mma_configs.items():
         if compute_capability < (7, 0):
             continue
-        elif compute_capability < (7, 5):
+        if compute_capability < (7, 5):
             if 'm16n8k8' in config_name and config.input_dtype == 'f16':
                 continue
         elif compute_capability < (8, 0):

--- a/python/hidet/ir/primitives/cuda/mma.py
+++ b/python/hidet/ir/primitives/cuda/mma.py
@@ -86,8 +86,11 @@ class MmaConfig:
         return mma_configs['m16n8k8_tf32_f32']
 
     @staticmethod
-    def all():
-        return list(mma_configs.values())
+    def all(compute_capability=None):
+        if compute_capability is None:
+            return list(mma_configs.values())
+        else:
+            return filter_mma_by_cc(compute_capability)
 
     def __str__(self):
         return self.inst_name()
@@ -216,6 +219,29 @@ def register_mma_instructions():
                 is_volatile=False,
             )
         register_primitive_function(name=func_name, func_or_type=fb.func)
+
+
+def filter_mma_by_cc(compute_capability):
+    supported_configs = []
+    for config_name, config in mma_configs.items():
+        if compute_capability < (7, 0):
+            continue
+        elif compute_capability < (7, 5):
+            if 'm16n8k8' in config_name and config.input_dtype == 'f16':
+                continue
+        elif compute_capability < (8, 0):
+            if 'm8n8k4' in config_name and config.input_dtype == 'f64':
+                continue
+            if 'm16n8k16' in config_name and config.input_dtype == 'f16':
+                continue
+            if ('m16n8k8' in config_name or 'm16n8k16' in config_name) and config.input_dtype == 'bf16':
+                continue
+            if ('m16n8k4' in config_name or 'm16n8k8' in config_name) and config.input_dtype == 'tf32':
+                continue
+
+        supported_configs.append(config)
+
+    return supported_configs
 
 
 def resolve_ldmatrix_func_name(num: int, shared_space_addr: bool = False, trans=False) -> str:


### PR DESCRIPTION
Some MMA configs are not valid in sm<80. Fix this by filtering out mma_configs before creating the tuning space.

This should address #225 

Also, I changed the warning for contiguous tensor to warn_once to reduce the amount of context printed to the consol. 