### PR TITLE
[Script] Add pointer arthematic 

### DIFF
--- a/python/hidet/backend/codegen.py
+++ b/python/hidet/backend/codegen.py
@@ -363,11 +363,14 @@ class Codegen(ModuleFunctor, StmtFunctor, ExprFunctor, TypeFunctor):
             return Text('"{}"'.format(e.value))
         elif e.is_scalar():
             return self.scalar_literal(e.value, e.type)
-        else:
-            assert isinstance(e.type, TensorType)
+        elif e.is_tensor():
             dtype = e.type.dtype
             items = [self.scalar_literal(v, dtype) for v in np.array(e.value).flatten()]
             return '{' + doc_join(items, ', ') + '}'
+        elif isinstance(e.type, PointerType):
+            return '(' + self(e.type) + ')' + str(int(e.value))
+        else:
+            raise ValueError("invalid constant type: {}".format(e))
 
     def visit_DeclareStmt(self, stmt: DeclareStmt):
         doc = NewLine()

--- a/python/hidet/ffi/packedfunc.py
+++ b/python/hidet/ffi/packedfunc.py
@@ -19,7 +19,7 @@ from ctypes import c_int32, c_void_p, pointer, c_float, cast
 from ctypes import POINTER, Structure
 
 import hidet.graph.frontend.torch
-from hidet.ir.type import TypeNode, DataType, TensorType, PointerType, TensorPointerType
+from hidet.ir.type import BaseType, DataType, TensorType, PointerType, TensorPointerType
 from hidet.ir.expr import Constant
 from .ffi import _LIB
 
@@ -34,7 +34,7 @@ class ArgTypeCode(Enum):
     FLOAT16 = 4
 
     @staticmethod
-    def from_type(type_node: TypeNode) -> ArgTypeCode:
+    def from_type(type_node: BaseType) -> ArgTypeCode:
         if isinstance(type_node, DataType):
             if type_node.name == 'int32':
                 return ArgTypeCode.INT32
@@ -54,7 +54,7 @@ class CPackedFunc(Structure):
     _fields_ = [("num_args", c_int32), ("arg_types", c_int32_p), ("func_pointer", c_void_p)]
 
 
-def make_c_packed_func(param_types: Sequence[TypeNode], c_func_pointer) -> CPackedFunc:
+def make_c_packed_func(param_types: Sequence[BaseType], c_func_pointer) -> CPackedFunc:
     type_codes = [ArgTypeCode.from_type(param_type).value for param_type in param_types]
     n = len(type_codes)
     num_args = c_int32(n)
@@ -64,8 +64,8 @@ def make_c_packed_func(param_types: Sequence[TypeNode], c_func_pointer) -> CPack
 
 
 class PackedFunc:
-    def __init__(self, param_types: Sequence[TypeNode], c_func_pointer):
-        self.param_types: List[TypeNode] = list(param_types)
+    def __init__(self, param_types: Sequence[BaseType], c_func_pointer):
+        self.param_types: List[BaseType] = list(param_types)
         self.c_packed_func: CPackedFunc = make_c_packed_func(param_types, c_func_pointer)
 
     def convert_args(self, args: Sequence):

--- a/python/hidet/graph/ops/schedules/auto_scheduler.py
+++ b/python/hidet/graph/ops/schedules/auto_scheduler.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 from typing import Union, List, Dict, Sequence, Tuple, Set, Optional
 
-from hidet.ir.type import DataType, tensor_pointer_type, void_pointer
+from hidet.ir.type import DataType, tensor_pointer_type, void_p
 from hidet.ir.expr import TensorElement, Expr, Var, SymbolVar, Constant, scalar_var, convert, cast
 from hidet.ir.stmt import Stmt, AssignStmt, ForStmt, DeclareStmt, BufferStoreStmt, AssertStmt
 from hidet.ir.task import Task
@@ -232,7 +232,7 @@ class AutoScheduler:
             # packed function arguments, packed_func(num_args: int32, arg_types: *int32, args: **void)
             num_args = scalar_var('num_args', 'int32')
             arg_types = Var('arg_types', ~int32)
-            args = Var('args', ~void_pointer())
+            args = Var('args', ~void_p)
             fb.extend_params([num_args, arg_types, args])
 
             # extract the packed arguments

--- a/python/hidet/ir/__init__.py
+++ b/python/hidet/ir/__init__.py
@@ -21,7 +21,7 @@ from . import task
 
 from .node import Node
 from .func import IRModule, Function
-from .type import TypeNode, TensorType, DataType, FuncType, VoidType, PointerType, TensorPointerType
+from .type import BaseType, TensorType, DataType, FuncType, VoidType, PointerType, TensorPointerType
 from .type import data_type, tensor_type, tensor_pointer_type
 
 from .expr import Expr, Var, Constant

--- a/python/hidet/ir/dialects/pattern.py
+++ b/python/hidet/ir/dialects/pattern.py
@@ -13,16 +13,16 @@ from __future__ import annotations
 from typing import Any, Tuple, Optional, Dict, ContextManager
 from contextlib import ExitStack
 from hidet.ir.node import Node
-from hidet.ir.type import TypeNode
+from hidet.ir.type import BaseType
 from hidet.ir.expr import Expr, Constant, Add, Sub, Multiply, Div, Mod, FloorDiv, LessThan, Equal, LessEqual
 from hidet.ir.expr import BitwiseXor
 from hidet.ir.expr import IfThenElse, LogicalAnd, LogicalOr, BinaryExpr
 
 
 class PlaceholderExpr(Expr):
-    def __init__(self, required_type: Optional[TypeNode] = None, require_const=False, require_non_const=False):
+    def __init__(self, required_type: Optional[BaseType] = None, require_const=False, require_non_const=False):
         super().__init__()
-        self.required_type: Optional[TypeNode] = required_type
+        self.required_type: Optional[BaseType] = required_type
         self.require_const: bool = require_const
         self.require_non_const: bool = require_non_const
         assert not (self.require_const and self.require_non_const), 'require placeholder to be both const & non-const'

--- a/python/hidet/ir/expr.py
+++ b/python/hidet/ir/expr.py
@@ -228,6 +228,13 @@ class Expr(Node):
                 return constant(a.value + b.value, a.type)
             elif a.type.is_data_type() and b.type.is_pointer():
                 return constant(a.value + b.value, b.type)
+            elif a.type.is_string_type() and b.type.is_string_type():
+                if cls is Add:
+                    return constant(a.value + b.value, a.type)
+                elif cls in [Equal, NotEqual]:
+                    return constant(operator_dict[cls](a.value, b.value), 'bool')
+                else:
+                    raise ValueError('unknown binary operator {}'.format(cls))
             else:
                 raise ValueError('unknown binary operator {}'.format(cls))
         elif isinstance(b, Constant) and b.type.is_data_type():
@@ -896,6 +903,8 @@ def constant(value, const_type: Union[str, BaseType]) -> Constant:
         value = np.array(value)
     elif isinstance(const_type, PointerType):
         value = int(value)
+    elif isinstance(const_type, StringType):
+        value = str(value)
     else:
         raise ValueError(f"Invalid const_type {const_type}")
 

--- a/python/hidet/ir/expr.py
+++ b/python/hidet/ir/expr.py
@@ -17,7 +17,7 @@ import string
 import operator
 import numpy as np
 from .node import Node
-from .type import TypeNode, TensorType, DataType, TensorPointerType, PointerType, FuncType, StringType
+from .type import BaseType, TensorType, DataType, TensorPointerType, PointerType, FuncType, StringType
 from .type import tensor_pointer_type, string_type, tensor_type, data_type
 
 PyScalar = Union[bool, int, float, complex, str]
@@ -201,7 +201,7 @@ class Expr(Node):
             return cls(a)
 
     @staticmethod
-    def _binary(cls, a, b):  # pylint: disable=bad-staticmethod-argument
+    def _binary(cls, a: Expr, b: Expr):  # pylint: disable=bad-staticmethod-argument
         if not isinstance(a, Expr):
             a = convert(a)
         if not isinstance(b, Expr):
@@ -209,14 +209,28 @@ class Expr(Node):
         if isinstance(a, Constant) and isinstance(b, Constant):
             from hidet.ir.dtypes import promote_type
 
-            value = operator_dict[cls](a.value, b.value)
-            if cls in [Equal, NotEqual, LessThan, LessEqual, LogicalAnd, LogicalOr]:
-                return constant(value, const_type='bool')
-            elif cls in [LeftShift, RightShift]:
-                return constant(value, a.type)
+            if a.type.is_data_type() and b.type.is_data_type():
+                value = operator_dict[cls](a.value, b.value)
+                if cls in [Equal, NotEqual, LessThan, LessEqual, LogicalAnd, LogicalOr]:
+                    return constant(value, const_type='bool')
+                elif cls in [LeftShift, RightShift]:
+                    return constant(value, a.type)
+                else:
+                    return constant(value, promote_type(a.type, b.type))
+            elif a.type.is_pointer() and b.type.is_pointer():
+                if cls is Sub:
+                    return constant(a.value - b.value, 'uint64')
+                elif cls in [Equal, NotEqual]:
+                    return constant(operator_dict[cls](a.value, b.value), 'bool')
+                else:
+                    raise ValueError('unknown binary operator {}'.format(cls))
+            elif a.type.is_pointer() and b.type.is_data_type():
+                return constant(a.value + b.value, a.type)
+            elif a.type.is_data_type() and b.type.is_pointer():
+                return constant(a.value + b.value, b.type)
             else:
-                return constant(value, promote_type(a.type, b.type))
-        elif isinstance(b, Constant):
+                raise ValueError('unknown binary operator {}'.format(cls))
+        elif isinstance(b, Constant) and b.type.is_data_type():
             from hidet.ir.dtypes import promote_type
             from hidet.ir.tools import infer_type
 
@@ -413,11 +427,11 @@ class Let(Expr):
 
 
 class Cast(Expr):
-    def __init__(self, expr, target_type: TypeNode):
+    def __init__(self, expr, target_type: BaseType):
         self.expr: Expr = expr
-        self.target_type: TypeNode = target_type
+        self.target_type: BaseType = target_type
 
-        assert isinstance(target_type, TypeNode)
+        assert isinstance(target_type, BaseType)
 
 
 class Constant(Expr):
@@ -425,10 +439,12 @@ class Constant(Expr):
     _constant_pool: Dict[Tuple[Union[int, float, bool], str], Constant] = {}
 
     def __init__(
-        self, value: Union[np.ndarray, float, int, complex, str], const_type: Union[DataType, StringType, TensorType]
+        self,
+        value: Union[np.ndarray, float, int, complex, str],
+        const_type: Union[DataType, StringType, TensorType, PointerType],
     ):
         self.value: Union[np.ndarray, float, int, complex, str] = value
-        self.type: Union[DataType, StringType, TensorType] = const_type
+        self.type: Union[DataType, StringType, TensorType, PointerType] = const_type
 
     def is_scalar(self) -> bool:
         return isinstance(self.type, DataType)
@@ -447,9 +463,6 @@ class Constant(Expr):
 
     def __bool__(self):
         return bool(self.value)
-
-    def __str__(self):
-        return str(self.value)
 
     def __complex__(self):
         return complex(self.value)
@@ -504,7 +517,7 @@ class Reference(Expr):
 class Var(Expr):
     id_clock = 0
 
-    def __init__(self, hint: Optional[str], type: TypeNode, name: Optional[str] = None):
+    def __init__(self, hint: Optional[str], type: BaseType, name: Optional[str] = None):
         """
         A variable may have a hint, name, and id.
 
@@ -520,7 +533,7 @@ class Var(Expr):
         """
         self.hint: Optional[str] = hint
         self.name: Optional[str] = name
-        self.type: Union[TypeNode, TensorType, TensorPointerType, FuncType] = type
+        self.type: Union[BaseType, TensorType, TensorPointerType, FuncType] = type
         self.id: int = self.new_id()
 
     @staticmethod
@@ -555,7 +568,6 @@ ExprInt8 = ExprInt16 = ExprInt32 = ExprInt64 = Expr
 ExprUInt8 = ExprUInt16 = ExprUInt32 = ExprUInt64 = Expr
 ExprFloat16 = ExprFloat32 = ExprFloat64 = ExprBFloat16 = ExprTFloat32 = Expr
 Int = Union[int, Expr]
-
 
 """
 The following are the mapping from hidet expression class to corresponding python operator.
@@ -807,7 +819,7 @@ def bitwise_xor(*args: Union[Expr, int]) -> BitwiseXor:
     return _chain_binary_op(BitwiseXor, args, 0)
 
 
-def cast(v: Expr, dtype: Union[str, DataType, TypeNode]):
+def cast(v: Expr, dtype: Union[str, DataType, BaseType]):
     if not isinstance(v, Expr):
         raise ValueError('Expect an expression, got {}'.format(type(v).__name__))
 
@@ -859,7 +871,7 @@ def is_constant(e: Union[Expr, PyScalar], *other: Union[Expr, PyScalar]) -> bool
     return True
 
 
-def constant(value, const_type) -> Constant:
+def constant(value, const_type: Union[str, BaseType]) -> Constant:
     from hidet.ir.dtypes import boolean
 
     if const_type and isinstance(const_type, str):
@@ -880,10 +892,16 @@ def constant(value, const_type) -> Constant:
             value = tuple(value)
         else:
             raise ValueError(f"Invalid data const_type {const_type}")
-    else:
+    elif isinstance(const_type, TensorType):
         value = np.array(value)
+    elif isinstance(const_type, PointerType):
+        value = int(value)
+    else:
+        raise ValueError(f"Invalid const_type {const_type}")
 
-    if (isinstance(value, int) and -128 <= value <= 128) or (isinstance(value, float) and value in [-1.0, 0.0, 1.0]):
+    if const_type.is_data_type() and (
+        (isinstance(value, int) and -128 <= value <= 128) or (isinstance(value, float) and value in [-1.0, 0.0, 1.0])
+    ):
         # pylint: disable=protected-access
         if (value, const_type.name) not in Constant._constant_pool:
             Constant._constant_pool[(value, const_type.name)] = Constant(value, const_type)

--- a/python/hidet/ir/func.py
+++ b/python/hidet/ir/func.py
@@ -12,7 +12,7 @@
 from typing import Dict, List, Union, Optional
 import string
 from hidet.ir.node import Node
-from hidet.ir.type import TypeNode, FuncType
+from hidet.ir.type import BaseType, FuncType
 from hidet.ir.expr import Var, Call
 from hidet.ir.stmt import Stmt
 
@@ -55,7 +55,7 @@ class Function(Node):
         assert isinstance(kind, str) and kind in ['cuda_device', 'cuda_kernel', 'host_kernel', 'packed_func']
         self.params: List[Var] = params
         self.body: Stmt = body
-        self.ret_type: TypeNode = ret_type
+        self.ret_type: BaseType = ret_type
         # self.extern_vars: List[Var] = extern_vars if extern_vars else []
         self.attrs: Dict[str, Union[int, float, str, Node]] = attrs if attrs else {}
 

--- a/python/hidet/ir/primitives/cuda/mma.py
+++ b/python/hidet/ir/primitives/cuda/mma.py
@@ -254,7 +254,7 @@ def resolve_ldmatrix_func_name(num: int, shared_space_addr: bool = False, trans=
 
 @initialize()
 def register_ldmatrix_instructions():
-    from hidet.lang import script, u32, void_pointer, attrs, ref_u32
+    from hidet.lang import script, u32, void_p, attrs, ref_u32
 
     for num in [1, 2, 4]:
         for trans in [False, True]:
@@ -265,7 +265,7 @@ def register_ldmatrix_instructions():
                 inst_name = 'ldmatrix.sync.aligned.m8n8{num}{trans}{ss}.b16'.format(
                     num=f'.x{num}', trans='.trans' if trans else '', ss='.shared' if shared_space_addr else ''
                 )
-                smem_type = u32 if shared_space_addr else void_pointer
+                smem_type = u32 if shared_space_addr else void_p
                 if num == 1:
                     template = '{inst_name} {{%0}}, [%1];'.format(inst_name=inst_name)
 

--- a/python/hidet/ir/tools/printer.py
+++ b/python/hidet/ir/tools/printer.py
@@ -218,7 +218,7 @@ class IRPrinter(IRFunctor):
             return 'ConstTensor({}, {})'.format(e.value.shape, e.type)
         elif e.is_string():
             return Text('"{}"'.format(str(e.value)))
-        else:
+        elif e.is_scalar():
             dtype = e.type.name
             if dtype == 'float32':
                 ret = '{}f'.format(float(e.value))
@@ -229,6 +229,10 @@ class IRPrinter(IRFunctor):
             else:
                 ret = '{}({})'.format(dtype, e.value)
             return Text(ret)
+        elif isinstance(e.type, PointerType):
+            return Text('({}){}'.format(self(e.type), self(e.value)))
+        else:
+            raise NotImplementedError("Unknown constant type: {}".format(e.type))
 
     def visit_DeclareStmt(self, stmt: DeclareStmt):
         doc = NewLine() + Text('declare ') + self(stmt.var) + Text(': ') + self(stmt.var.type)

--- a/python/hidet/ir/tools/type_infer.py
+++ b/python/hidet/ir/tools/type_infer.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from hidet.ir.type import DataType, TensorType, FuncType, PointerType, TensorPointerType, data_type, tensor_pointer_type
-from hidet.ir.type import tensor_type
+from hidet.ir.type import tensor_type, BaseType
 from hidet.ir.expr import BinaryExpr, Add, Sub, Multiply, Div, Mod, FloorDiv, Condition, LessThan, Equal, IfThenElse
 from hidet.ir.expr import TensorSlice, LogicalNot, LogicalOr, LogicalAnd, LessEqual, Let, RightShift, LeftShift
 from hidet.ir.expr import BitwiseAnd, Neg, NotEqual, BitwiseXor, Dereference, Reference, Address, BitwiseNot, BitwiseOr
@@ -35,15 +35,35 @@ class TypeInfer(ExprFunctor, ComputeFunctor):
     def visit_Binary(self, e: BinaryExpr):
         from hidet.ir.utils.type_utils import numeric_promotion
 
-        a_dtype: DataType = self.visit(e.a)
-        b_dtype: DataType = self.visit(e.b)
+        a_type: BaseType = self.visit(e.a)
+        b_type: BaseType = self.visit(e.b)
+        if a_type.is_data_type() and b_type.is_data_type():
+            a_dtype: DataType = a_type.as_data_type()
+            b_dtype: DataType = b_type.as_data_type()
 
-        if isinstance(e, (Add, Sub, Multiply, Div, Mod, FloorDiv)):
-            return numeric_promotion(a_dtype, b_dtype)
-        elif isinstance(e, Condition):
-            return data_type('bool')
+            if isinstance(e, (Add, Sub, Multiply, Div, Mod, FloorDiv)):
+                return numeric_promotion(a_dtype, b_dtype)
+            elif isinstance(e, Condition):
+                return data_type('bool')
+            else:
+                raise NotImplementedError('Binary operator type infer {}'.format(type(e)))
+        elif a_type.is_pointer() and b_type.is_pointer():
+            if isinstance(e, Sub):
+                return data_type('int32')
+            else:
+                raise TypeError("Can only do pointer subtraction, got {}".format(type(e)))
+        elif a_type.is_pointer() and b_type.is_data_type():
+            if isinstance(e, (Sub, Add)):
+                return a_type
+            else:
+                raise TypeError("Can only pointer +/- integer, got {} {} {}".format(a_type, type(e), b_type))
+        elif a_type.is_data_type() and b_type.is_pointer():
+            if isinstance(e, Add):
+                return b_type
+            else:
+                raise TypeError("Can only integer + pointer, got {} {} {}".format(a_type, type(e), b_type))
         else:
-            raise NotImplementedError('Binary op type infer {}'.format(type(e)))
+            raise NotImplementedError('Binary operator type infer {} {} {}'.format(a_type, type(e), b_type))
 
     def visit_Neg(self, e: Neg):
         return self(e.a)

--- a/python/hidet/ir/type.py
+++ b/python/hidet/ir/type.py
@@ -47,6 +47,9 @@ class BaseType(Node):
     def is_func_type(self):
         return isinstance(self, FuncType)
 
+    def is_string_type(self):
+        return isinstance(self, StringType)
+
     def as_data_type(self) -> Optional[DataType]:
         if not isinstance(self, DataType):
             return None

--- a/python/hidet/ir/type.py
+++ b/python/hidet/ir/type.py
@@ -195,7 +195,7 @@ class PointerType(BaseType):
         self.use_bracket: bool = use_bracket
 
     def __call__(self, x):
-        from hidet.ir.expr import Constant, Expr, constant, cast    # pylint: disable=redefined-outer-name
+        from hidet.ir.expr import Constant, Expr, constant, cast  # pylint: disable=redefined-outer-name
 
         if isinstance(x, int):
             return constant(x, self)

--- a/python/hidet/ir/type.py
+++ b/python/hidet/ir/type.py
@@ -195,7 +195,7 @@ class PointerType(BaseType):
         self.use_bracket: bool = use_bracket
 
     def __call__(self, x):
-        from hidet.ir.expr import Constant, Expr, constant, cast
+        from hidet.ir.expr import Constant, Expr, constant, cast    # pylint: disable=redefined-outer-name
 
         if isinstance(x, int):
             return constant(x, self)

--- a/python/hidet/ir/type.py
+++ b/python/hidet/ir/type.py
@@ -20,8 +20,8 @@ Expr = 'Expr'
 Int = Union[int, Expr]
 
 
-class TypeNode(Node):
-    def __invert__(self) -> TypeNode:
+class BaseType(Node):
+    def __invert__(self) -> BaseType:
         # get the pointer type that points to current type
         if isinstance(self, TensorType):
             return TensorPointerType.from_tensor_type(self)
@@ -47,13 +47,13 @@ class TypeNode(Node):
     def is_func_type(self):
         return isinstance(self, FuncType)
 
-    def as_data_type(self) -> DataType:
+    def as_data_type(self) -> Optional[DataType]:
         if not isinstance(self, DataType):
-            raise ValueError('Can not convert {} to DataType'.format(self))
+            return None
         return self
 
 
-class DataType(TypeNode):
+class DataType(BaseType):
     """
     The data type that defines how to interpret the data in memory.
     """
@@ -146,7 +146,7 @@ class DataType(TypeNode):
         raise NotImplementedError()
 
 
-class TensorType(TypeNode):
+class TensorType(BaseType):
     def __init__(self, dtype=None, shape=None, layout=None):
         """
         A tensor type.
@@ -176,32 +176,44 @@ class TensorType(TypeNode):
         return [int(v) for v in self.shape]
 
 
-class VoidType(TypeNode):
+class VoidType(BaseType):
     pass
 
 
-class StringType(TypeNode):
+class StringType(BaseType):
     pass
 
 
-class PointerType(TypeNode):
+class PointerType(BaseType):
     def __init__(self, base_type, specifiers: Optional[Sequence[str]] = None, use_bracket: bool = False):
         super().__init__()
         if isinstance(base_type, str):
             base_type = data_type(base_type)
-        self.base_type: TypeNode = base_type
+        self.base_type: BaseType = base_type
         # todo: move the following attributes to DeclareStmt
         self.specifiers: List[str] = list(specifiers) if specifiers else []
         self.use_bracket: bool = use_bracket
 
+    def __call__(self, x):
+        from hidet.ir.expr import Constant, Expr, constant, cast
 
-class ReferenceType(TypeNode):
+        if isinstance(x, int):
+            return constant(x, self)
+        elif isinstance(x, Constant):
+            return constant(x.value, self)
+        elif isinstance(x, Expr):
+            return cast(x, self)
+        else:
+            raise ValueError('Can not convert {} to {}'.format(x, self))
+
+
+class ReferenceType(BaseType):
     def __init__(self, base_type):
         super().__init__()
         self.base_type = base_type
 
 
-class TensorPointerType(TypeNode):
+class TensorPointerType(BaseType):
     def __init__(self, ttype: TensorType):
         """
         A pointer type that points to tensor.
@@ -215,15 +227,15 @@ class TensorPointerType(TypeNode):
         return tpt
 
 
-TypeLike = Union[str, TypeNode]
+TypeLike = Union[str, BaseType]
 
 
-class FuncType(TypeNode):
+class FuncType(BaseType):
     def __init__(
         self,
         param_types: Optional[List[TypeLike]] = None,
         ret_type: Optional[TypeLike] = None,
-        type_infer_func: Optional[Callable] = None,  # Callable[[a number of TypeNode], TypeNode]
+        type_infer_func: Optional[Callable] = None,  # Callable[[a number of BaseType], BaseType]
     ):
         self.param_types = [self._convert_type(tp) for tp in param_types] if param_types is not None else None
         self.ret_type = self._convert_type(ret_type) if ret_type is not None else None
@@ -231,14 +243,14 @@ class FuncType(TypeNode):
         msg = 'Please provide either a static type or a type infer func'
         assert not all(v is None for v in [ret_type, type_infer_func]), msg
 
-    def ret_type_on(self, arg_types: List[TypeNode]) -> TypeNode:
+    def ret_type_on(self, arg_types: List[BaseType]) -> BaseType:
         if self.ret_type is not None:
             # todo: add type checking
             return self.ret_type
         else:
             return self.type_infer_func(arg_types)
 
-    def _convert_type(self, tp: Union[str, TypeNode]):
+    def _convert_type(self, tp: Union[str, BaseType]):
         if isinstance(tp, str):
             return data_type(tp)
         else:
@@ -306,10 +318,6 @@ def pointer_type(base_type):
 
 def tensor_pointer_type(dtype, shape=None, layout=None):
     return TensorPointerType(tensor_type(dtype, shape, layout))
-
-
-def void_pointer():
-    return PointerType(VoidType())
 
 
 def string_type():

--- a/python/hidet/lang/__init__.py
+++ b/python/hidet/lang/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Union, Sequence, Optional, List
-from hidet.ir.type import TypeNode, DataType, TensorType, PointerType, VoidType, ReferenceType, void_p, data_type
+from hidet.ir.type import BaseType, DataType, TensorType, PointerType, VoidType, ReferenceType, void_p, data_type
 from hidet.ir.expr import Expr, Var, cast, view, address, Dereference
 from hidet.ir.mapping import row_spatial, row_repeat, col_repeat, col_spatial, TaskMapping, auto_map
 from hidet.ir.layout import DataLayout
@@ -30,7 +30,6 @@ from hidet.lang.constructs.type import tensor, tensor_pointer, as_tensor_pointer
 
 ref_u32 = ReferenceType(u32)
 
-void_pointer = PointerType(VoidType())
 void = VoidType()
 
 spatial = row_spatial

--- a/python/hidet/lang/constructs/type.py
+++ b/python/hidet/lang/constructs/type.py
@@ -10,44 +10,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Union, Optional, Sequence
-from hidet.ir.type import TypeNode, DataType, tensor_type
+from hidet.ir.type import BaseType, DataType, tensor_type
 from hidet.ir.layout import DataLayout
 from hidet.ir.expr import Expr, cast
 from hidet.ir.stmt import DeclareScope
 
 
 class TypeDecorator:
-    def __init__(self, decorated_type: TypeNode, scope: Optional[Union[str, DeclareScope]], is_static: bool = False):
+    def __init__(self, decorated_type: BaseType, scope: Optional[Union[str, DeclareScope]], is_static: bool = False):
         if isinstance(scope, str):
             scope = DeclareScope.from_str(scope)
-        self.decorated_type: TypeNode = decorated_type
+        self.decorated_type: BaseType = decorated_type
         self.scope = scope
         self.is_static = is_static
 
 
-def static(tp: Union[TypeNode, TypeDecorator]):
-    if isinstance(tp, TypeNode):
+def static(tp: Union[BaseType, TypeDecorator]):
+    if isinstance(tp, BaseType):
         return TypeDecorator(decorated_type=tp, scope=None, is_static=True)
     else:
         return TypeDecorator(decorated_type=tp.decorated_type, scope=tp.scope, is_static=True)
 
 
-def with_scope(scope: Union[str, DeclareScope], tp: Union[TypeNode, TypeDecorator]):
-    if isinstance(tp, TypeNode):
+def with_scope(scope: Union[str, DeclareScope], tp: Union[BaseType, TypeDecorator]):
+    if isinstance(tp, BaseType):
         return TypeDecorator(decorated_type=tp, scope=scope, is_static=False)
     else:
         return TypeDecorator(decorated_type=tp.decorated_type, scope=scope, is_static=tp.is_static)
 
 
-def shared_scope(tp: Union[TypeNode, TypeDecorator]):
+def shared_scope(tp: Union[BaseType, TypeDecorator]):
     return with_scope(DeclareScope.Shared, tp)
 
 
-def register_scope(tp: Union[TypeNode, TypeDecorator]):
+def register_scope(tp: Union[BaseType, TypeDecorator]):
     return with_scope(DeclareScope.Register, tp)
 
 
-def global_scope(tp: Union[TypeNode, TypeDecorator]):
+def global_scope(tp: Union[BaseType, TypeDecorator]):
     return with_scope(DeclareScope.Global, tp)
 
 

--- a/python/hidet/lang/transpiler.py
+++ b/python/hidet/lang/transpiler.py
@@ -322,7 +322,7 @@ class PythonToHidetTranslator(PythonAstFunctor):
         # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         # check the rhs value, must be an instance of allowed_types or a list of these kinds of elements.
         host_var_types = (ir.TaskMapping, ir.DataLayout, ir.TensorSlice, ir.Function, str, list, tuple, dict)
-        allowed_types = (ir.Expr, ir.TypeNode, TypeDecorator, float, int, str, type(None))
+        allowed_types = (ir.Expr, ir.BaseType, TypeDecorator, float, int, str, type(None))
         allowed_types += host_var_types
         assert isinstance(rhs, allowed_types) or (
             isinstance(rhs, list) and all(isinstance(v, allowed_types) for v in rhs)
@@ -360,7 +360,7 @@ class PythonToHidetTranslator(PythonAstFunctor):
                         init_value = None
                         is_static = False
                         scope = DeclareScope.Default
-                        if isinstance(rhs, ir.TypeNode):
+                        if isinstance(rhs, ir.BaseType):
                             var_type = rhs
                         elif isinstance(rhs, TypeDecorator):
                             var_type = rhs.decorated_type
@@ -437,7 +437,7 @@ class PythonToHidetTranslator(PythonAstFunctor):
                     if arg_name not in self.func_annotations:
                         raise HidetProgramError(self, arg, 'Hidet expects type annotation for each function argument.')
                     arg_type = self.func_annotations[arg_name]
-                    if isinstance(arg_type, ir.TypeNode):
+                    if isinstance(arg_type, ir.BaseType):
                         if isinstance(arg_type, ir.TensorType):
                             # we automatically change the tensor type of argument to a tensor pointer type.
                             arg_type = ir.tensor_pointer_type(
@@ -481,7 +481,7 @@ class PythonToHidetTranslator(PythonAstFunctor):
                 ret_type = ir.VoidType()
             else:
                 ret_type = self.visit(func_def.returns)
-                if not isinstance(ret_type, ir.TypeNode):
+                if not isinstance(ret_type, ir.BaseType):
                     raise HidetProgramError(self, func_def.returns, 'Expect a type of function return value.')
 
             # get function attributes
@@ -659,9 +659,9 @@ class PythonToHidetTranslator(PythonAstFunctor):
                 # case 1: get the address of an expression
                 # case 2: get the pointer type that points to the given type
                 from hidet.ir.expr import Address
-                from hidet.ir.type import TypeNode
+                from hidet.ir.type import BaseType
 
-                if isinstance(value, TypeNode):
+                if isinstance(value, BaseType):
                     return ~value
                 else:
                     return Address(value)

--- a/tests/script/test_constant.py
+++ b/tests/script/test_constant.py
@@ -1,0 +1,46 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import hidet
+
+
+def test_const_pointer():
+    from hidet.lang import attrs, void_p, printf, int32
+
+    with hidet.script_module() as script_module:
+
+        @hidet.script
+        def func():
+            attrs.func_kind = 'host_kernel'
+
+            v = int32(0)  # int32 v = 0;
+            p_int32 = ~v  # int32* p_int32 = &v;
+            p_void = void_p(p_int32)  # void* p_void = (void*)p_int32;
+            printf("%p\n", p_void)
+
+            p_void_0 = void_p(0)  # void* p_void_0 = (void*)0;
+            printf("%p\n", p_void_0)
+
+            p_void_1 = p_void_0 + 1
+            p_void_2 = p_void_1 - 1
+            printf("%p\n", p_void_1)
+            printf("%p\n", p_void_2)
+            printf("%d\n", p_void_1 == p_void_2)
+            printf("%d\n", p_void_1 == p_void_2 + 1)
+            printf("%p\n", p_int32 + 1)
+
+    func = script_module.build()
+    func()
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
```python
def test_const_pointer():
    from hidet.lang import attrs, void_p, printf, int32

    with hidet.script_module() as script_module:

        @hidet.script
        def func():
            attrs.func_kind = 'host_kernel'

            v = int32(0)  # int32 v = 0;
            p_int32 = ~v  # int32* p_int32 = &v;
            p_void = void_p(p_int32)  # void* p_void = (void*)p_int32;
            printf("%p\n", p_void)

            p_void_0 = void_p(0)  # void* p_void_0 = (void*)0;
            printf("%p\n", p_void_0)

            p_void_1 = p_void_0 + 1
            p_void_2 = p_void_1 - 1
            printf("%p\n", p_void_1)
            printf("%p\n", p_void_2)
            printf("%d\n", p_void_1 == p_void_2)
            printf("%d\n", p_void_1 == p_void_2 + 1)
            printf("%p\n", p_int32 + 1)

    func = script_module.build()
    func()
```

```text
0x7ffdc4cbeb2c
(nil)
0x1
0x2
0
0
0x7ffdc4cbeb30
```