### PR TITLE
[Hidet Script] Allow `bind_tuple` argument in `mapping.on(...)` and `grid(...)`

### DIFF
--- a/python/hidet/ir/mapping.py
+++ b/python/hidet/ir/mapping.py
@@ -74,10 +74,10 @@ class TaskMapping(Node):
     def __getitem__(self, w: Int) -> List[Tuple[Int, ...]]:
         return self.worker2task(w)
 
-    def on(self, w: Int):
+    def on(self, w: Int, bind_tuple=False):
         from hidet.lang.constructs.loops import TaskMappingLoopIterable
 
-        return TaskMappingLoopIterable(self, w)
+        return TaskMappingLoopIterable(self, w, bind_tuple)
 
     def map(self, w: Int) -> Tuple[Int, ...]:
         return self.single_task_of(w)

--- a/python/hidet/lang/constructs/loops.py
+++ b/python/hidet/lang/constructs/loops.py
@@ -38,10 +38,11 @@ class HidetLoopIterable:
 
 
 class TaskMappingLoopIterable(HidetLoopIterable):
-    def __init__(self, task_mapping: TaskMapping, worker):
+    def __init__(self, task_mapping: TaskMapping, worker, bind_tuple=False):
         super().__init__()
         self.task_mapping: TaskMapping = task_mapping
         self.worker: Expr = worker
+        self._bind_tuple: bool = bind_tuple
 
     def __iter__(self):
         return iter(self.task_mapping.worker2task(self.worker))
@@ -52,6 +53,9 @@ class TaskMappingLoopIterable(HidetLoopIterable):
 
     def num_loop_vars(self) -> int:
         return len(self.task_mapping.task_shape)
+
+    def bind_tuple(self) -> bool:
+        return self._bind_tuple
 
 
 class GridLoopIterable(HidetLoopIterable):
@@ -94,7 +98,7 @@ class RangeLoopIterable(HidetLoopIterable):
         return 1
 
 
-def grid(*dim_extents, attrs: Optional[str] = None):
+def grid(*dim_extents, attrs: Optional[str] = None, bind_tuple=False):
     """
     Iterate over the grid.
 
@@ -115,6 +119,9 @@ def grid(*dim_extents, attrs: Optional[str] = None):
       for indices in grid([2]):  # indices is a tuple with one element
           printf("%d %d\n", indices[0])
 
+      for indices in grid(2, bind_tuple=True):  # indices is a tuple with one element
+          printf("%d %d\n", indices[0])
+
     Usage 3: specify the loop attribute
       for i, j in grid(2, 3, attrs='up'):   # loop i is unrolled while loop j is parallelized
           printf("%d %d\n", i, j)
@@ -133,7 +140,6 @@ def grid(*dim_extents, attrs: Optional[str] = None):
         The sequence of indices in the grid to be iterated. (This is the semantics of hidet script, not this python
         function.)
     """
-    bind_tuple = False
     if len(dim_extents) == 1 and isinstance(dim_extents[0], (list, tuple)):
         dim_extents = dim_extents[0]
         bind_tuple = True

--- a/tests/script/test_for_loops.py
+++ b/tests/script/test_for_loops.py
@@ -131,3 +131,35 @@ def test_softmax(shape: List[int], axis: int):
     y2 = hidet.empty(shape)
     func(x, y2)
     numpy.testing.assert_allclose(y1.numpy(), y2.numpy(), rtol=1e-5, atol=1e-5)
+
+
+def test_bind_tuple():
+    from hidet.lang import attrs
+    from hidet.lang.mapping import spatial, repeat
+    from hidet.lang import printf, grid
+
+    with hidet.script_module() as script_module:
+
+        @hidet.script
+        def launch():
+            attrs.func_kind = 'public'
+
+            for w in grid(3, attrs='p'):
+                for indices in repeat(2).spatial(3).on(w, bind_tuple=True):
+                    printf("%d %d\n", w, indices[0])
+
+            for w in grid(3, attrs='p'):
+                for i in repeat(2).spatial(3).on(w):
+                    printf("%d %d\n", w, i)
+
+            for indices in grid(3, bind_tuple=True):
+                printf("%d\n", indices[0])
+
+            for indices in grid([3]):
+                printf("%d\n", indices[0])
+
+            for i in grid(3):
+                printf("%d\n", i)
+
+    cm = script_module.build()
+    cm()


### PR DESCRIPTION
See the following usage examples:
```python
def test_bind_tuple():
    from hidet.lang import attrs
    from hidet.lang.mapping import spatial, repeat
    from hidet.lang import printf, grid

    with hidet.script_module() as script_module:

        @hidet.script
        def launch():
            attrs.func_kind = 'public'

            for w in grid(3, attrs='p'):
                for indices in repeat(2).spatial(3).on(w, bind_tuple=True):   
                    # indices is a tuple with a single integer 
                    printf("%d %d\n", w, indices[0])

            for w in grid(3, attrs='p'):     # i is an integer
                for i in repeat(2).spatial(3).on(w):
                    printf("%d %d\n", w, i)

            for indices in grid(3, bind_tuple=True):
                printf("%d\n", indices[0])

            for indices in grid([3]):
                printf("%d\n", indices[0])

            for i in grid(3):
                printf("%d\n", i)

    cm = script_module.build()
    cm()
```