### PR TITLE
[Hidet Script] Add `in` and `not in` expression in hidet script

### DIFF
--- a/python/hidet/ir/expr.py
+++ b/python/hidet/ir/expr.py
@@ -677,7 +677,7 @@ def is_false(v: Expr) -> bool:
 
 def if_then_else(
     cond: Union[Expr, PyScalar], then_expr: Union[Expr, PyScalar], else_expr: Union[Expr, PyScalar]
-) -> IfThenElse:
+) -> Expr:
     """
     Create an if-then-else expression.
 
@@ -694,10 +694,16 @@ def if_then_else(
 
     Returns
     -------
-    ret: IfThenElse
+    ret: Expr
         The if-then-else expression.
     """
-    return IfThenElse(convert(cond), convert(then_expr), convert(else_expr))
+    if is_constant(cond):
+        if bool(cond):
+            return convert(then_expr)
+        else:
+            return convert(else_expr)
+    else:
+        return IfThenElse(convert(cond), convert(then_expr), convert(else_expr))
 
 
 def tensor_rank(v: Expr) -> int:

--- a/tests/script/test_meta.py
+++ b/tests/script/test_meta.py
@@ -37,3 +37,26 @@ def test_meta_range():
 
     module = script_module.build()
     module()
+
+
+def test_if_then_else():
+    from hidet.lang import attrs, tensor
+
+    dims = [2, 3]
+
+    with hidet.script_module() as script_module:
+
+        @hidet.script
+        def launch():
+            attrs.func_kind = 'public'
+
+            a = tensor('default', 'float32', shape=[2, 3, 4, 5])
+            indices = [0, 1, 2, 3]
+            updated_indices = [indices[i] if i in dims else 0 for i in range(len(indices))]
+            a[updated_indices] = 1.0
+
+            updated_indices = [indices[i] if i not in dims else 0 for i in range(len(indices))]
+            a[updated_indices] = 2.0
+
+    cm = script_module.build()
+    cm()


### PR DESCRIPTION
Usage:

```python
def test_if_then_else():
    from hidet.lang import attrs, tensor

    dims = [2, 3]

    with hidet.script_module() as script_module:

        @hidet.script
        def launch():
            attrs.func_kind = 'public'

            a = tensor('default', 'float32', shape=[2, 3, 4, 5])
            indices = [0, 1, 2, 3]
            updated_indices = [indices[i] if i in dims else 0 for i in range(len(indices))]
            a[updated_indices] = 1.0

            updated_indices = [indices[i] if i not in dims else 0 for i in range(len(indices))]
            a[updated_indices] = 2.0

    cm = script_module.build()
    cm()
```

IRModule:
```
def launch()
    # func_kind: public
    declare a: tensor(float32, [2, 3, 4, 5])
    a[0, 0, 2, 3] = 1.0f
    a[0, 1, 0, 0] = 2.0f
```