### PR TITLE
[External Tasks] Move task build into method call for external kernel support

### DIFF
--- a/python/hidet/drivers/build_task.py
+++ b/python/hidet/drivers/build_task.py
@@ -245,7 +245,7 @@ def build_task_batch(task_target_pairs: List[Tuple[Task, str]]):
     def build_job(args):
         try:
             task, target = args
-            build_task(task, target, load=False)
+            task.build(target, load=False)
             return True, 'Success'
         except (Exception,):  # pylint: disable=broad-except
             import traceback

--- a/python/hidet/graph/ops/conv2d_transpose/conv2d_transpose.py
+++ b/python/hidet/graph/ops/conv2d_transpose/conv2d_transpose.py
@@ -61,7 +61,7 @@ class Conv2dTransposeTask(Task):
                         data[ni, (ci // wc) * og + ogi, (hi + px0 - kxi) // sx, (wi + py0 - kyi) // sy]
                         * weight[(ci // wc) * og + ogi, ci % wc, kxi, kyi]
                     ),
-                    else_expr=0.0,
+                    else_expr=data.type.dtype.zero,
                 ),
                 reduce_type='sum',
             ),

--- a/python/hidet/ir/task.py
+++ b/python/hidet/ir/task.py
@@ -210,7 +210,7 @@ class Task(Node):
                 raise ValueError('Unknown parameter type: {}'.format(type(param)))
         return arguments
 
-    def build(self, target: Union[str, Target]):
+    def build(self, target: Union[str, Target], load: bool = True):
         """
         Build the task for the given target to a callable function.
 
@@ -219,6 +219,8 @@ class Task(Node):
         target: Union[str, Target]
             The target device.
 
+        load: bool
+            Whether to load the task
         Returns
         -------
         func: hidet.runtime.CompiledTask
@@ -228,7 +230,7 @@ class Task(Node):
 
         if isinstance(target, Target):
             target = target.name
-        return build_task(self, target=target, load=True)
+        return build_task(self, target=target, load=load)
 
     def implement(self, target: Union[Target, str], working_dir: str) -> List[IRModule]:
         from hidet.ir.schedulers import CudaAutoScheduler, CpuAutoScheduler


### PR DESCRIPTION
This is to support adding tasks from outside of the hidet library that uses external build logic. 

User can directly overwrite the `build` function to insert custom logic for introducing operators to hidet graph