### PR TITLE
[Document] fix installation guide

### DIFF
--- a/docs/source/getting-started/build-from-source.rst
+++ b/docs/source/getting-started/build-from-source.rst
@@ -2,7 +2,7 @@ Build from source
 -------------------
 .. _Build-from-source:
 
-If you want to contribute to Hidet, or you encountered any problem installing hidet via pip, it is better to install
+If you want to contribute to Hidet, or you encountered any problem directly installing hidet via pip, it is better to install
 hidet from source.
 
 Clone the code
@@ -32,21 +32,15 @@ shared library:
 
 After building, you could find two libraries ``libhidet.so`` and ``libhidet_runtime.so`` under ``build/lib`` directory.
 
-Update environment variables
+Install the Hidet Python package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To allow Python interpreter to find hidet package under ``python`` directory of the repository, we should append the
-directory to ``PYTHONPATH`` variable. To allow the system find the shared libraries we built in the previous step,
-we should append ``build/lib`` directory to ``LD_LIBRARY_PATH`` variable.
+Next we will install the Python package of Hidet in the develop mode via pip:
 
 .. code-block:: console
 
-  $ export HIDET_HOME=<The Path to Hidet Repo>
-  $ export PYTHONPATH=$PYTHONPATH:$HIDET_HOME/python
-  $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HIDET_HOME/build/lib
-
-To avoid repeating above commands, it is recommended to put above commands to your shell's initialization script
-(e.g., ``~/.bashrc`` for Bash and ``~/.zshrc`` for Zsh).
+  $ cd .. # return to the root directory of Hidet
+  $ pip install -e .
 
 Validation
 ~~~~~~~~~~


### PR DESCRIPTION
Merely assigning environment variables is insufficient for setting up dev environment now. We need to run pip to install hidet package in develop mode.

Users still need to build source files written in C++ manually. Consider integrating that into `setup.py` in the future?