### PR TITLE
[FixBug] Don't instantiate symbol for primitive functions

### DIFF
--- a/python/hidet/transforms/instantiate_symbols.py
+++ b/python/hidet/transforms/instantiate_symbols.py
@@ -59,7 +59,7 @@ class InstantiateSymbolsRewriter(IRRewriter):
                 symbols.update(func_symbols.symbols)
             else:
                 assert False
-        
+
         if is_primitive_function(func.name):
             return func
 

--- a/python/hidet/transforms/instantiate_symbols.py
+++ b/python/hidet/transforms/instantiate_symbols.py
@@ -15,6 +15,7 @@ from hidet.ir.expr import Var, SymbolVar, Call
 from hidet.ir.func import Function
 from hidet.ir.module import IRModule
 from hidet.ir.functors import IRRewriter
+from hidet.ir.primitives import is_primitive_function
 from hidet.ir.primitives.runtime import get_symbol_value
 from hidet.ir.stmt import LetStmt, LaunchKernelStmt
 from hidet.ir.tools import collect
@@ -58,6 +59,9 @@ class InstantiateSymbolsRewriter(IRRewriter):
                 symbols.update(func_symbols.symbols)
             else:
                 assert False
+        
+        if is_primitive_function(func.name):
+            return func
 
         ordered_symbols: List[SymbolVar] = list(symbols)
         symbol_params: List[Var] = [Var(symbol.name, symbol.type) for symbol in ordered_symbols]


### PR DESCRIPTION
Previously, if a primitive function calls a primitive function, the `instantiate_symbols` pass will update the corresponding `hidet.ir.primitives.func.PrimitiveFunctionRegistry.function` in-place (I am not sure exactly how it's done, but this is what I observed), adding symbol variables to its parameters. The primitive function pool is a global variable, therefore this effect is cumulative across tuning candidates. So while candidate 0 will have no problem, candidate 1 will have two extra copies of symbol params, and so on, leading to compile errors.

Since primitive functions do not need symbol vars, a quick fix is just to not instantiate any symbols for them.