### PR TITLE
[Fixbug] Is exiting fix

### DIFF
--- a/python/hidet/utils/exiting.py
+++ b/python/hidet/utils/exiting.py
@@ -32,7 +32,7 @@ _is_exiting = False
 
 def is_exiting():
     """Returns True if the python interpreter is exiting."""
-    return _is_exiting is None or _is_exiting is True
+    return _is_exiting is True
 
 
 def _at_exit():

--- a/python/hidet/utils/exiting.py
+++ b/python/hidet/utils/exiting.py
@@ -32,7 +32,7 @@ _is_exiting = False
 
 def is_exiting():
     """Returns True if the python interpreter is exiting."""
-    return _is_exiting is True
+    return _is_exiting is None or _is_exiting is True
 
 
 def _at_exit():

--- a/python/hidet/utils/exiting.py
+++ b/python/hidet/utils/exiting.py
@@ -32,7 +32,7 @@ _is_exiting = False
 
 def is_exiting():
     """Returns True if the python interpreter is exiting."""
-    return _is_exiting is None or _is_exiting is False
+    return _is_exiting is None or _is_exiting is True
 
 
 def _at_exit():

--- a/tests/operators/test_conv2d.py
+++ b/tests/operators/test_conv2d.py
@@ -58,10 +58,7 @@ def torch_conv2d(
     "device", ["cuda"]
 )  # we don't test for cpu because its quite imprecise in fp16 for larger kernel sizes
 def test_conv2d_gemm_fp16(n, c, h, w, oc, kx, ky, groups, stride, dilations, parallel_k, device):
-    if device == 'cpu':
-        tol = 0.8
-    else:
-        tol = 0.5
+    tol = 0.8
     check_binary(
         a_shape=[n, c, h, w],
         b_shape=[oc, c // groups, kx, ky],


### PR DESCRIPTION
_is_exiting is set to True by at_exit, and False in the usual case, the logic currently is flipped.

Now that is_exiting is working properly, we are actually clearning up memory. As a result, I found a different bug where dummy input creation is not properly handled for different data types (e.g. int types that are used for indexing)

This was not found before because we are re-using old memory regions and somehow these old allocations had proper values in them. 