### PR TITLE
[Enhancements] add a vcude device to help mitigate compile time GPU memory usage

### DIFF
--- a/python/hidet/graph/flow_graph.py
+++ b/python/hidet/graph/flow_graph.py
@@ -537,7 +537,7 @@ class FlowGraph:
         for x in self.inputs:
             if not x.device.is_cuda():
                 raise ValueError("Inputs must be on cuda device")
-            x._move_to_vcuda()
+            x.move_to_vcuda()
 
         for node in self.nodes:
             if 'device' in node.attrs:
@@ -546,9 +546,9 @@ class FlowGraph:
                     dev = Device('vcuda', dev.id)
                 node.attrs['device'] = dev
             for inp in node.inputs:
-                inp._move_to_vcuda()
+                inp.move_to_vcuda()
             for outp in node.outputs:
-                outp._move_to_vcuda()
+                outp.move_to_vcuda()
 
     def from_vcuda(self) -> None:
         """
@@ -559,7 +559,7 @@ class FlowGraph:
         for x in self.inputs:
             if not x.device.is_vcuda():
                 raise ValueError("Inputs must be on vcuda device")
-            x._move_from_vcuda()
+            x.move_from_vcuda()
 
         for node in self.nodes:
             if 'device' in node.attrs:
@@ -568,9 +568,9 @@ class FlowGraph:
                     dev = Device('cuda', dev.id)
                 node.attrs['device'] = dev
             for inp in node.inputs:
-                inp._move_from_vcuda()
+                inp.move_from_vcuda()
             for outp in node.outputs:
-                outp._move_from_vcuda()
+                outp.move_from_vcuda()
 
 
 def trace_from(tensor: Union[Tensor, List[Tensor]], inputs: Optional[Union[Tensor, List[Tensor]]] = None) -> FlowGraph:

--- a/python/hidet/graph/flow_graph.py
+++ b/python/hidet/graph/flow_graph.py
@@ -528,7 +528,7 @@ class FlowGraph:
 
         return free_vars, nodes, usage_count
 
-    def to_vcuda(self) -> None:
+    def vcuda_(self) -> None:
         """
         casts the flow graph object to vcuda device in place
         """
@@ -537,7 +537,7 @@ class FlowGraph:
         for x in self.inputs:
             if not x.device.is_cuda():
                 raise ValueError("Inputs must be on cuda device")
-            x.move_to_vcuda()
+            x.vcuda_()
 
         for node in self.nodes:
             if 'device' in node.attrs:
@@ -546,11 +546,11 @@ class FlowGraph:
                     dev = Device('vcuda', dev.id)
                 node.attrs['device'] = dev
             for inp in node.inputs:
-                inp.move_to_vcuda()
+                inp.vcuda_()
             for outp in node.outputs:
-                outp.move_to_vcuda()
+                outp.vcuda_()
 
-    def from_vcuda(self) -> None:
+    def cuda_(self) -> None:
         """
         casts the flow graph object from vcuda device in place
         """
@@ -559,7 +559,7 @@ class FlowGraph:
         for x in self.inputs:
             if not x.device.is_vcuda():
                 raise ValueError("Inputs must be on vcuda device")
-            x.move_from_vcuda()
+            x.cuda_()
 
         for node in self.nodes:
             if 'device' in node.attrs:
@@ -568,9 +568,9 @@ class FlowGraph:
                     dev = Device('cuda', dev.id)
                 node.attrs['device'] = dev
             for inp in node.inputs:
-                inp.move_from_vcuda()
+                inp.cuda_()
             for outp in node.outputs:
-                outp.move_from_vcuda()
+                outp.cuda_()
 
 
 def trace_from(tensor: Union[Tensor, List[Tensor]], inputs: Optional[Union[Tensor, List[Tensor]]] = None) -> FlowGraph:

--- a/python/hidet/graph/flow_graph.py
+++ b/python/hidet/graph/flow_graph.py
@@ -546,9 +546,11 @@ class FlowGraph:
                     dev = Device('vcuda', dev.id)
                 node.attrs['device'] = dev
             for inp in node.inputs:
-                inp.vcuda_()
+                if inp.device.is_cuda():
+                    inp.vcuda_()
             for outp in node.outputs:
-                outp.vcuda_()
+                if outp.device.is_cuda():
+                    outp.vcuda_()
 
     def cuda_(self) -> None:
         """
@@ -568,9 +570,11 @@ class FlowGraph:
                     dev = Device('cuda', dev.id)
                 node.attrs['device'] = dev
             for inp in node.inputs:
-                inp.cuda_()
+                if inp.device.is_vcuda():
+                    inp.cuda_()
             for outp in node.outputs:
-                outp.cuda_()
+                if outp.device.is_vcuda():
+                    outp.cuda_()
 
 
 def trace_from(tensor: Union[Tensor, List[Tensor]], inputs: Optional[Union[Tensor, List[Tensor]]] = None) -> FlowGraph:

--- a/python/hidet/graph/flow_graph.py
+++ b/python/hidet/graph/flow_graph.py
@@ -528,7 +528,7 @@ class FlowGraph:
 
         return free_vars, nodes, usage_count
 
-    def _to_vcuda(self) -> None:
+    def to_vcuda(self) -> None:
         """
         casts the flow graph object to vcuda device in place
         """
@@ -550,7 +550,7 @@ class FlowGraph:
             for outp in node.outputs:
                 outp._move_to_vcuda()
 
-    def _from_vcuda(self) -> None:
+    def from_vcuda(self) -> None:
         """
         casts the flow graph object from vcuda device in place
         """

--- a/python/hidet/graph/operator.py
+++ b/python/hidet/graph/operator.py
@@ -66,7 +66,7 @@ class Operator:
             if len(self.inputs) == 0:
                 raise ValueError('Cannot infer device from an operator with no inputs and "device" attribute')
             # when the operator has inputs, get the device from the inputs
-            if not all(t.device == self.inputs[0].device for t in self.inputs):
+            if not all(t.device.target == self.inputs[0].device.target for t in self.inputs):
                 raise ValueError('All inputs of an operator must be on the same device')
             return self.inputs[0].device
 
@@ -84,10 +84,12 @@ class Operator:
 
         if isinstance(self, TransferOp):
             return 'cuda'
-        elif self.device.is_vcuda():
-            return 'cuda'
+        if self.device.kind in ["cuda", "vcuda"]:
+            return "cuda"
+        elif self.device.kind == "cpu":
+            return "cpu"
         else:
-            return self.device.kind
+            raise NotImplementedError()
 
     @property
     def compiled_task(self) -> CompiledTask:

--- a/python/hidet/graph/operator.py
+++ b/python/hidet/graph/operator.py
@@ -84,6 +84,8 @@ class Operator:
 
         if isinstance(self, TransferOp):
             return 'cuda'
+        elif self.device.is_vcuda():
+            return 'cuda'
         else:
             return self.device.kind
 

--- a/python/hidet/graph/tensor.py
+++ b/python/hidet/graph/tensor.py
@@ -789,6 +789,45 @@ class Tensor:
             else:
                 return transfer(self, device)
 
+    def _move_to_vcuda(self):
+        """Cast the tensor to vcuda device in place.
+
+        If the current tensor is already on vcuda device, self is returned.
+
+        Returns
+        -------
+        ret: None
+            This operation is in-place
+        """
+
+        if self.device.is_vcuda():
+            return self
+        if not self.device.is_cuda():
+            raise ValueError("Tensor must be on cuda device, got {}".format(self.device))
+        # if the tensor has no storage, there is no need to cast
+        if self.storage is not None:
+            self._storage = self.storage.vcuda(self.device.id)
+        self._device = Device('vcuda', self.device.id)
+
+    def _move_from_vcuda(self):
+        """Cast the tensor from vcuda device in place.
+
+        If the current tensor is already on cuda device, self is returned.
+
+        Returns
+        -------
+        ret: None
+            This operation is in-place
+        """
+        if self.device.is_cuda():
+            return self
+        if not self.device.is_vcuda():
+            raise ValueError("Tensor must be on vcuda device, got {}".format(self.device))
+
+        if self.storage is not None:
+            self._storage = self.storage.cuda(self.device.id)
+        self._device = Device('cuda', self.device.id)
+
     def copy(self) -> Tensor:
         """Create a copy of current tensor.
 

--- a/python/hidet/graph/tensor.py
+++ b/python/hidet/graph/tensor.py
@@ -789,10 +789,10 @@ class Tensor:
             else:
                 return transfer(self, device)
 
-    def move_to_vcuda(self):
+    def vcuda_(self):
         """Cast the tensor to vcuda device in place.
 
-        If the current tensor is already on vcuda device, self is returned.
+        If the current tensor is already on vcuda device, nothing is performed
 
         Returns
         -------
@@ -809,10 +809,10 @@ class Tensor:
             self._storage = self.storage.vcuda(self.device.id)
         self._device = Device('vcuda', self.device.id)
 
-    def move_from_vcuda(self):
+    def cuda_(self):
         """Cast the tensor from vcuda device in place.
 
-        If the current tensor is already on cuda device, self is returned.
+        If the current tensor is already on cuda device, nothing is performed
 
         Returns
         -------

--- a/python/hidet/graph/tensor.py
+++ b/python/hidet/graph/tensor.py
@@ -789,7 +789,7 @@ class Tensor:
             else:
                 return transfer(self, device)
 
-    def _move_to_vcuda(self):
+    def move_to_vcuda(self):
         """Cast the tensor to vcuda device in place.
 
         If the current tensor is already on vcuda device, self is returned.
@@ -801,7 +801,7 @@ class Tensor:
         """
 
         if self.device.is_vcuda():
-            return self
+            return
         if not self.device.is_cuda():
             raise ValueError("Tensor must be on cuda device, got {}".format(self.device))
         # if the tensor has no storage, there is no need to cast
@@ -809,7 +809,7 @@ class Tensor:
             self._storage = self.storage.vcuda(self.device.id)
         self._device = Device('vcuda', self.device.id)
 
-    def _move_from_vcuda(self):
+    def move_from_vcuda(self):
         """Cast the tensor from vcuda device in place.
 
         If the current tensor is already on cuda device, self is returned.
@@ -820,7 +820,7 @@ class Tensor:
             This operation is in-place
         """
         if self.device.is_cuda():
-            return self
+            return
         if not self.device.is_vcuda():
             raise ValueError("Tensor must be on vcuda device, got {}".format(self.device))
 

--- a/python/hidet/graph/transforms/base.py
+++ b/python/hidet/graph/transforms/base.py
@@ -262,6 +262,12 @@ class PassContext:
         self.instruments.append(ProfileInstrument(log_file, print_stdout))
         return self
 
+    def reduce_cuda_compile_mem(self, enabale=True):
+        from .instruments import ConvertGraphToVCuda  # pylint: disable=import-outside-toplevel
+
+        self.instruments.append(ConvertGraphToVCuda())
+        return self
+
 
 class GraphPass:
     def __init__(self):

--- a/python/hidet/graph/transforms/base.py
+++ b/python/hidet/graph/transforms/base.py
@@ -262,11 +262,18 @@ class PassContext:
         self.instruments.append(ProfileInstrument(log_file, print_stdout))
         return self
 
-    def reduce_cuda_compile_mem(self, enabale=True):
+    def reduce_cuda_compile_mem(self, enable: Optional[bool] = None):
+        """
+        Reduce CUDA memory used during compilation by using vcuda tensors, might incur compile time cost
+        Parameters
+        ----------
+        enable: Optional[bool]
+            When given, will always enable or disable this instrument.
+            If no argument is given, the compiler will decide to enable this with some heuristics
+        """
         from .instruments import ConvertGraphToVCuda  # pylint: disable=import-outside-toplevel
 
-        self.instruments.append(ConvertGraphToVCuda())
-        return self
+        self.instruments.append(ConvertGraphToVCuda(enable))
 
 
 class GraphPass:

--- a/python/hidet/graph/transforms/instruments/convert_flowgraph_to_vcuda.py
+++ b/python/hidet/graph/transforms/instruments/convert_flowgraph_to_vcuda.py
@@ -10,13 +10,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from hidet.graph.flow_graph import FlowGraph
-
+from hidet.graph.graph_utils.functors import graph_collect
+from hidet.cuda.device import properties, current_device
 from .base import GraphPassInstrument
 
 
 class ConvertGraphToVCuda(GraphPassInstrument):
+    def __init__(self, enable: bool):
+        super().__init__()
+        self.enable = enable
+        self.applied = False
+
+        # passes may take up to 2x memory (80% of total memory)
+        self.threshold = 0.4
+
     def before_all_passes(self, graph: FlowGraph):
-        graph.to_vcuda()
+        if not self.should_enable(graph):
+            return
+        graph.vcuda_()
+        self.applied = True
 
     def after_all_passes(self, graph: FlowGraph) -> None:
-        graph.from_vcuda()
+        if self.applied:
+            graph.cuda_()
+            self.applied = False
+
+    def should_enable(self, graph):
+        from hidet.graph import Tensor
+
+        if self.enable is None:
+            tensors = graph_collect(graph, Tensor)
+            graph_size = 0
+            for t in tensors:
+                if t.storage is not None and t.storage.device.is_cuda():
+                    graph_size += t.storage.num_bytes
+
+            return graph_size / properties(current_device()).totalGlobalMem > self.threshold
+        else:
+            return self.enable

--- a/python/hidet/graph/transforms/instruments/convert_flowgraph_to_vcuda.py
+++ b/python/hidet/graph/transforms/instruments/convert_flowgraph_to_vcuda.py
@@ -9,9 +9,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-
-from hidet import utils
 from hidet.graph.flow_graph import FlowGraph
 
 from .base import GraphPassInstrument
@@ -19,7 +16,7 @@ from .base import GraphPassInstrument
 
 class ConvertGraphToVCuda(GraphPassInstrument):
     def before_all_passes(self, graph: FlowGraph):
-        graph._to_vcuda()
+        graph.to_vcuda()
 
     def after_all_passes(self, graph: FlowGraph) -> None:
-        graph._from_vcuda()
+        graph.from_vcuda()

--- a/python/hidet/graph/transforms/instruments/convert_flowgraph_to_vcuda.py
+++ b/python/hidet/graph/transforms/instruments/convert_flowgraph_to_vcuda.py
@@ -9,7 +9,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+
+from hidet import utils
+from hidet.graph.flow_graph import FlowGraph
+
 from .base import GraphPassInstrument
-from .profile_instrument import ProfileInstrument
-from .save_graph_instrument import SaveGraphInstrument
-from .convert_flowgraph_to_vcuda import ConvertGraphToVCuda
+
+
+class ConvertGraphToVCuda(GraphPassInstrument):
+    def before_all_passes(self, graph: FlowGraph):
+        graph._to_vcuda()
+
+    def after_all_passes(self, graph: FlowGraph) -> None:
+        graph._from_vcuda()

--- a/python/hidet/runtime/compiled_task.py
+++ b/python/hidet/runtime/compiled_task.py
@@ -177,19 +177,19 @@ class CompiledTask:
 
         outputs = self.create_outputs()
 
-        has_vcuda = len(inputs) > 0 and all([inp.device.is_vcuda() for inp in inputs])
+        has_vcuda = len(inputs) > 0 and all(inp.device.is_vcuda() for inp in inputs)
         if has_vcuda:
             for inp in inputs:
-                inp._move_from_vcuda()
+                inp.move_from_vcuda()
 
         candidate = self.candidates[self.pick_best_candidate(inputs, outputs)]
         candidate(*inputs, *outputs)
 
         if has_vcuda:
             for inp in inputs:
-                inp._move_to_vcuda()
+                inp.move_to_vcuda()
             for outp in outputs:
-                outp._move_to_vcuda()
+                outp.move_to_vcuda()
 
         return outputs
 

--- a/python/hidet/runtime/compiled_task.py
+++ b/python/hidet/runtime/compiled_task.py
@@ -176,8 +176,21 @@ class CompiledTask:
             _check_inputs(self.meta_data.inputs, inputs)
 
         outputs = self.create_outputs()
+
+        has_vcuda = len(inputs) > 0 and all([inp.device.is_vcuda() for inp in inputs])
+        if has_vcuda:
+            for inp in inputs:
+                inp._move_from_vcuda()
+
         candidate = self.candidates[self.pick_best_candidate(inputs, outputs)]
         candidate(*inputs, *outputs)
+
+        if has_vcuda:
+            for inp in inputs:
+                inp._move_to_vcuda()
+            for outp in outputs:
+                outp._move_to_vcuda()
+
         return outputs
 
 
@@ -213,7 +226,10 @@ def _check_inputs(traced_inputs: Iterable[TensorSignature], inputs):
 
     symbol_map = {}
     for i, (traced, new) in enumerate(zip(traced_inputs, inputs)):
-        if traced.device.partition(':')[0] != new.device.kind:
+        traced_dev_kind = traced.device.partition(':')[0]
+        if traced_dev_kind != new.device.kind:
+            if traced_dev_kind == 'cuda' and new.device.is_vcuda():
+                continue
             raise RuntimeError(
                 f"device mismatch at arg {i} between original: {traced.device} and new: {new.device.kind}"
             )

--- a/python/hidet/runtime/device.py
+++ b/python/hidet/runtime/device.py
@@ -114,7 +114,7 @@ def instantiate_device(dev) -> Device:
     if dev.kind == 'cpu':
         dev.id = None  # CPU device does not have a device index
         return dev
-    elif dev.kind == 'cuda' or dev.kind == 'vcuda':
+    elif dev.kind in ['cuda', 'vcuda']:
         if dev.id is None:
             dev.id = current_device()
         return dev

--- a/python/hidet/runtime/device.py
+++ b/python/hidet/runtime/device.py
@@ -57,6 +57,10 @@ class Device:
     def is_vcuda(self) -> bool:
         return self.kind == 'vcuda'
 
+    @property
+    def target(self) -> str:
+        return 'cuda' if self.kind in ['cuda', 'vcuda'] else 'cpu'
+
 
 def device(device_type: str, device_index: Optional[int] = None):
     if ':' in device_type:

--- a/python/hidet/runtime/device.py
+++ b/python/hidet/runtime/device.py
@@ -54,6 +54,9 @@ class Device:
     def is_cuda(self) -> bool:
         return self.kind == 'cuda'
 
+    def is_vcuda(self) -> bool:
+        return self.kind == 'vcuda'
+
 
 def device(device_type: str, device_index: Optional[int] = None):
     if ':' in device_type:
@@ -70,8 +73,8 @@ def device(device_type: str, device_index: Optional[int] = None):
             raise ValueError(f'Invalid device_index: {device_index}')
         device_index = int(device_index)
 
-    if device_type not in ['cpu', 'cuda']:
-        raise ValueError(f'Invalid device_type: {device_type}, must be "cpu" or "cuda"')
+    if device_type not in ['cpu', 'cuda', 'vcuda']:
+        raise ValueError(f'Invalid device_type: {device_type}, must be "cpu" "cuda" or "vcuda"')
 
     if device_index is not None and not isinstance(device_index, int):
         raise ValueError(f'Invalid device_index: {device_index}, must be an integer')
@@ -111,7 +114,7 @@ def instantiate_device(dev) -> Device:
     if dev.kind == 'cpu':
         dev.id = None  # CPU device does not have a device index
         return dev
-    elif dev.kind == 'cuda':
+    elif dev.kind == 'cuda' or dev.kind == 'vcuda':
         if dev.id is None:
             dev.id = current_device()
         return dev

--- a/python/hidet/runtime/storage.py
+++ b/python/hidet/runtime/storage.py
@@ -243,6 +243,22 @@ class Storage:
         """
         return Storage._convert(self, Device('cuda', dst_id), non_blocking=True, stream=stream)
 
+    def vcuda(self, dst_id: int) -> Storage:
+        """
+        Copy the storage to CUDA device. If the storage is already on the device, return itself.
+
+        Parameters
+        ----------
+        dst_id: int
+            The id of the destination CUDA device.
+
+        Returns
+        -------
+        ret: Storage
+            The storage on the destination CUDA device.
+        """
+        return Storage._convert(self, Device('vcuda', dst_id), non_blocking=False)
+
     def copy(self) -> Storage:
         """
         Copy the storage to the same device. If the storage is already on the device, return itself.
@@ -368,7 +384,7 @@ class DeviceMemoryPools:
                     self.device2pool[device] = MemoryPool(
                         CudaMemoryAPI(device), block_size=4096, max_reserve_size=4 * 1024**3
                     )
-                elif device.is_cpu():
+                elif device.is_cpu() or device.is_vcuda():
                     self.device2pool[device] = MemoryPool(
                         CUDAHostMemoryAPI(device), block_size=4096, max_reserve_size=512 * 1024**2
                     )

--- a/python/hidet/testing/models/llama.py
+++ b/python/hidet/testing/models/llama.py
@@ -450,7 +450,9 @@ def get_compiled_model(name='decapoda-research/llama-7b-hf', device='cuda', opt=
     flow_graph = build_flow_graph(model, device=device)
 
     if opt:
-        flow_graph = hidet.graph.optimize(flow_graph)
+        with hidet.graph.PassContext() as ctx:
+            ctx.reduce_cuda_compile_mem(True)
+            flow_graph = hidet.graph.optimize(flow_graph)
 
     compiled = flow_graph.build()
     return compiled, config, tok

--- a/python/hidet/testing/models/llama.py
+++ b/python/hidet/testing/models/llama.py
@@ -357,8 +357,8 @@ def convert_model(hf_model: torch.nn.Module, dtype=hidet.float16, device='cuda')
 
 def build_flow_graph(model, batch_size=1, device='cuda', dtype='float16'):
     config = model.config
-    input_ids = hidet.symbol([batch_size, "seq_length"], dtype=hidet.int32, device=device)
-    position_ids = hidet.symbol([batch_size, config.max_position_embeddings], dtype=hidet.int32, device=device)
+    input_ids = hidet.symbol([batch_size, "seq_length"], dtype=hidet.int64, device=device)
+    position_ids = hidet.symbol([batch_size, config.max_position_embeddings], dtype=hidet.int64, device=device)
 
     get_sym = lambda: hidet.symbol(
         [batch_size, config.num_attention_heads, "prev_seq_len", config.hidden_size // config.num_attention_heads],
@@ -383,9 +383,9 @@ def build_flow_graph(model, batch_size=1, device='cuda', dtype='float16'):
 
 def generate(text: str, model, tokenizer, config, num_tokens=20, device='cuda', dtype='float16'):
     input_ids = tokenizer.encode(text)
-    input_ids = hidet.asarray([input_ids]).to(dtype=hidet.int32, device=device)
+    input_ids = hidet.asarray([input_ids]).to(dtype=hidet.int64, device=device)
 
-    position_ids = hidet.arange(0, config.max_position_embeddings, dtype=hidet.int32, device=device).unsqueeze(0)
+    position_ids = hidet.arange(0, config.max_position_embeddings, dtype=hidet.int64, device=device).unsqueeze(0)
 
     make_past = lambda: hidet.zeros(
         [1, config.num_attention_heads, 0, config.hidden_size // config.num_attention_heads], device=device, dtype=dtype

--- a/python/hidet/testing/models/llama.py
+++ b/python/hidet/testing/models/llama.py
@@ -438,8 +438,7 @@ def generate_torch(input_ids: str, tokenizer, torch_model, num_tokens, device='c
 def get_compiled_model(name='decapoda-research/llama-7b-hf', device='cuda', opt=False):
     tok = LlamaTokenizer.from_pretrained(name)
 
-    with torch.device("cuda"):  # reduce the time to load the model
-        model = hfLm.from_pretrained(name, torch_dtype=torch.float16)
+    model = hfLm.from_pretrained(name, torch_dtype=torch.float16)
     model.cpu()
     torch.cuda.empty_cache()
 

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -11,15 +11,17 @@
 # limitations under the License.
 import pytest
 from hidet.testing.models.llama import get_compiled_model, generate
+from hidet.runtime.storage import current_memory_pool
 
 
-@pytest.mark.skip(reason='This test requires a lot of memory')
-def test_llama(device='cuda', opt=False):
+@pytest.mark.parametrize('device,opt', [('cuda', False), ('cuda', True)])
+def test_llama(device, opt):
     model, config, tokenizer = get_compiled_model(device=device, opt=opt)
 
     text = generate('In the beginning was the Word.', model, tokenizer, config, num_tokens=12)
     print(text)
-    # assert text == 'The Word was with God, and the Word was God.'
+    expected = 'The Word was with God, and the Word was God.'
+    assert text == expected
 
     text = generate(
         "A robot may not injure a human being or, through inaction", model, tokenizer, config, num_tokens=55
@@ -27,8 +29,11 @@ def test_llama(device='cuda', opt=False):
     expected = (
         ', allow a human being to come to harm. A robot must obey the orders given it by human beings'
         ' except where such orders would conflict with the First Law. A robot must protect its own'
-        ' existence as long as such protection does not conflict with the First or Second Laws'
+        ' existence as long as such protection does not conflict with the First or Second Laws.'
     )
     print(text)
-    # assert text == expected
+    assert text == expected
 
+    print(current_memory_pool("cuda"))
+    print(current_memory_pool("cpu"))
+    print(current_memory_pool("vcuda"))

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -14,7 +14,7 @@ from hidet.testing.models.llama import get_compiled_model, generate
 from hidet.runtime.storage import current_memory_pool
 
 
-@pytest.mark.parametrize('device,opt', [('cuda', False), ('cuda', True)])
+@pytest.mark.parametrize('device,opt', [('cuda', True)])
 def test_llama(device, opt):
     model, config, tokenizer = get_compiled_model(device=device, opt=opt)
 
@@ -26,18 +26,11 @@ def test_llama(device, opt):
     text = generate(
         "A robot may not injure a human being or, through inaction", model, tokenizer, config, num_tokens=55
     )
-    if opt:
-        expected = (
-            ', allow a human being to come to harm. A robot must obey orders given it by human beings'
-            ' except where such orders would conflict with the First Law. A robot must protect its own'
-            ' existence as long as such protection does not conflict with the First or Second Laws'
-        )
-    else:
-        expected = (
-            ', allow a human being to come to harm. A robot must obey the orders given it by human beings'
-            ' except where such orders would conflict with the First Law. A robot must protect its own'
-            ' existence as long as such protection does not conflict with the First or Second Laws'
-        )
+    expected = (
+        ', allow a human being to come to harm. A robot must obey orders given it by human beings'
+        ' except where such orders would conflict with the First Law. A robot must protect its own'
+        ' existence as long as such protection does not conflict with the First or Second Laws.'
+    )
 
 
     print(text)

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -14,7 +14,8 @@ from hidet.testing.models.llama import get_compiled_model, generate
 from hidet.runtime.storage import current_memory_pool
 
 
-@pytest.mark.parametrize('device,opt', [('cuda', True)])
+# @pytest.mark.parametrize('device,opt', [('cuda', True)])
+@pytest.mark.skip(reason='This test requires a lot of CPU memory > 32GB')
 def test_llama(device, opt):
     model, config, tokenizer = get_compiled_model(device=device, opt=opt)
 

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -26,11 +26,19 @@ def test_llama(device, opt):
     text = generate(
         "A robot may not injure a human being or, through inaction", model, tokenizer, config, num_tokens=55
     )
-    expected = (
-        ', allow a human being to come to harm. A robot must obey orders given it by human beings'
-        ' except where such orders would conflict with the First Law. A robot must protect its own'
-        ' existence as long as such protection does not conflict with the First or Second Laws.'
-    )
+    if opt:
+        expected = (
+            ', allow a human being to come to harm. A robot must obey orders given it by human beings'
+            ' except where such orders would conflict with the First Law. A robot must protect its own'
+            ' existence as long as such protection does not conflict with the First or Second Laws'
+        )
+    else:
+        expected = (
+            ', allow a human being to come to harm. A robot must obey the orders given it by human beings'
+            ' except where such orders would conflict with the First Law. A robot must protect its own'
+            ' existence as long as such protection does not conflict with the First or Second Laws'
+        )
+
 
     print(text)
     assert text == expected

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -29,3 +29,6 @@ def test_llama(device='cuda', opt=False):
         ' existence as long as such protection does not conflict with the First or Second Laws'
     )
     assert text == expected
+
+
+test_llama(opt=True)

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -18,7 +18,8 @@ def test_llama(device='cuda', opt=False):
     model, config, tokenizer = get_compiled_model(device=device, opt=opt)
 
     text = generate('In the beginning was the Word.', model, tokenizer, config, num_tokens=12)
-    assert text == 'The Word was with God, and the Word was God.'
+    print(text)
+    # assert text == 'The Word was with God, and the Word was God.'
 
     text = generate(
         "A robot may not injure a human being or, through inaction", model, tokenizer, config, num_tokens=55
@@ -28,7 +29,6 @@ def test_llama(device='cuda', opt=False):
         ' except where such orders would conflict with the First Law. A robot must protect its own'
         ' existence as long as such protection does not conflict with the First or Second Laws'
     )
-    assert text == expected
+    print(text)
+    # assert text == expected
 
-
-test_llama(opt=True)

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -39,3 +39,5 @@ def test_llama(device, opt):
     print(current_memory_pool("cuda"))
     print(current_memory_pool("cpu"))
     print(current_memory_pool("vcuda"))
+
+test_llama('cuda', True)

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -39,5 +39,3 @@ def test_llama(device, opt):
     print(current_memory_pool("cuda"))
     print(current_memory_pool("cpu"))
     print(current_memory_pool("vcuda"))
-
-test_llama('cuda', True)

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -32,11 +32,9 @@ def test_llama(device, opt):
         ' existence as long as such protection does not conflict with the First or Second Laws.'
     )
 
-
     print(text)
     assert text == expected
 
     print(current_memory_pool("cuda"))
     print(current_memory_pool("cpu"))
     print(current_memory_pool("vcuda"))
-

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -27,13 +27,15 @@ def test_llama(device, opt):
         "A robot may not injure a human being or, through inaction", model, tokenizer, config, num_tokens=55
     )
     expected = (
-        ', allow a human being to come to harm. A robot must obey the orders given it by human beings'
+        ', allow a human being to come to harm. A robot must obey orders given it by human beings'
         ' except where such orders would conflict with the First Law. A robot must protect its own'
         ' existence as long as such protection does not conflict with the First or Second Laws.'
     )
+
     print(text)
     assert text == expected
 
     print(current_memory_pool("cuda"))
     print(current_memory_pool("cpu"))
     print(current_memory_pool("vcuda"))
+


### PR DESCRIPTION
## The problem
During compilation, some passes needs to replace certain operators with one or more new operators. For example, resolve_variants, subgraph_rewrite. In doing so, hidet relies on `imperative_run` to generate the new operators. This creates a lot of intermediate tensors that can exceed the actual run-time memory consumption, which makes larger models (such as Llama-7B) unable to compile even for a GPU with 24GB using fp16. 

## Fix
We introduce a vcuda device that allows GPU tensors to be stored on CPU and only transferred to GPU on demand. We call this v`cuda`. With this change, any additional GPU memory usage during compilation is off-loaded to CPU.

This might incur a bit compilation overhead when enabled, but given the time-consuming nature of such large models, this compile time increase is negligible. 

Now, on RTX3090, this is the GPU memory consumption for running llama test

```
Status of cuda:0 memory pool
   Allocated: 14081 MiB
        Peak: 14081 MiB
    Reserved: 1196 MiB
      Active: 12884 MiB
Status of cpu memory pool
   Allocated: 4 KiB
        Peak: 26022 MiB
    Reserved: 4 KiB
      Active: 0 Bytes
Status of vcuda:0 memory pool
   Allocated: 0 Bytes
        Peak: 25486 MiB
    Reserved: 0 Bytes
      Active: 0 Bytes
```
