### PR TITLE
[Distributed] Add more runtime distributed communication functions 

### DIFF
--- a/python/hidet/cuda/nccl/__init__.py
+++ b/python/hidet/cuda/nccl/__init__.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .ffi import nccl_available, nccl_version, nccl_library_filename
+from .ffi import nccl_available, nccl_version, nccl_library_filename, group_start, group_end
 from .comm import (
     create_comm,
     NcclUniqueId,

--- a/python/hidet/cuda/nccl/comm.py
+++ b/python/hidet/cuda/nccl/comm.py
@@ -124,6 +124,12 @@ class NcclCommunicator:
         nccl_runtime_api.reduce_scatter(
             sendbuff, recvbuff, recvcount, int(dtype_to_nccl(datatype)), int(str_to_nccl_op(op)), self._handle, s
         )
+    
+    def send(
+        self, sendbuff: int, count: int, datatype: DataType, peer: int, s: Optional[Stream] = None 
+    ):
+        if s is None:
+            s = current_stream()
 
 
 def create_comm(nranks: int, unique_id: NcclUniqueId, rank: int) -> NcclCommunicator:

--- a/python/hidet/cuda/nccl/comm.py
+++ b/python/hidet/cuda/nccl/comm.py
@@ -126,7 +126,7 @@ class NcclCommunicator:
         if s is None:
             s = current_stream()
         nccl_runtime_api.reduce_scatter(
-            sendbuff, recvbuff, recvcount, int(dtype_to_nccl(datatype)), op, self._handle, s
+            sendbuff, recvbuff, recvcount, int(dtype_to_nccl(datatype)), int(str_to_nccl_op(op)), self._handle, s
         )
 
 

--- a/python/hidet/cuda/nccl/comm.py
+++ b/python/hidet/cuda/nccl/comm.py
@@ -124,12 +124,16 @@ class NcclCommunicator:
         nccl_runtime_api.reduce_scatter(
             sendbuff, recvbuff, recvcount, int(dtype_to_nccl(datatype)), int(str_to_nccl_op(op)), self._handle, s
         )
-    
-    def send(
-        self, sendbuff: int, count: int, datatype: DataType, peer: int, s: Optional[Stream] = None 
-    ):
+
+    def send(self, sendbuff: int, count: int, datatype: DataType, peer: int, s: Optional[Stream] = None):
         if s is None:
             s = current_stream()
+        nccl_runtime_api.send(sendbuff, count, int(dtype_to_nccl(datatype)), peer, self._handle, s)
+
+    def recv(self, recvbuff: int, count: int, datatype: DataType, peer: int, s: Optional[Stream] = None):
+        if s is None:
+            s = current_stream()
+        nccl_runtime_api.recv(recvbuff, count, int(dtype_to_nccl(datatype)), peer, self._handle, s)
 
 
 def create_comm(nranks: int, unique_id: NcclUniqueId, rank: int) -> NcclCommunicator:

--- a/python/hidet/cuda/nccl/comm.py
+++ b/python/hidet/cuda/nccl/comm.py
@@ -88,6 +88,48 @@ class NcclCommunicator:
             sendbuff, recvbuff, count, int(dtype_to_nccl(datatype)), int(str_to_nccl_op(op)), self._handle, s
         )
 
+    def broadcast(
+        self, sendbuff: int, recvbuff: int, count: int, datatype: DataType, root: int, s: Optional[Stream] = None
+    ):
+        if s is None:
+            s = current_stream()
+        nccl_runtime_api.broadcast(sendbuff, recvbuff, count, int(dtype_to_nccl(datatype)), root, self._handle, s)
+
+    def reduce(
+        self,
+        sendbuff: int,
+        recvbuff: int,
+        count: int,
+        datatype: DataType,
+        op: int,
+        root: int,
+        s: Optional[Stream] = None,
+    ):
+        if s is None:
+            s = current_stream()
+        nccl_runtime_api.reduce(
+            sendbuff, recvbuff, count, int(dtype_to_nccl(datatype)), int(str_to_nccl_op(op)), root, self._handle, s
+        )
+    
+    def all_gather(
+        self, sendbuff: int, recvbuff: int, sendcount: int, datatype: DataType, s: Optional[Stream] = None,
+    ):
+        if s is None:
+            s = current_stream()
+        nccl_runtime_api.all_gather(
+            sendbuff, recvbuff, sendcount, int(dtype_to_nccl(datatype)), self._handle, s
+        )        
+    
+    def reduce_scatter(
+        self, sendbuff: int, recvbuff: int, recvcount: int, datatype: DataType, op: int, s: Optional[Stream] = None
+    ):
+        if s is None:
+            s = current_stream()
+        nccl_runtime_api.reduce_scatter(
+            sendbuff, recvbuff, recvcount, int(dtype_to_nccl(datatype)), op, self._handle, s
+        )
+
+
 
 def create_comm(nranks: int, unique_id: NcclUniqueId, rank: int) -> NcclCommunicator:
     if not nccl_available():

--- a/python/hidet/cuda/nccl/comm.py
+++ b/python/hidet/cuda/nccl/comm.py
@@ -110,16 +110,12 @@ class NcclCommunicator:
         nccl_runtime_api.reduce(
             sendbuff, recvbuff, count, int(dtype_to_nccl(datatype)), int(str_to_nccl_op(op)), root, self._handle, s
         )
-    
-    def all_gather(
-        self, sendbuff: int, recvbuff: int, sendcount: int, datatype: DataType, s: Optional[Stream] = None,
-    ):
+
+    def all_gather(self, sendbuff: int, recvbuff: int, sendcount: int, datatype: DataType, s: Optional[Stream] = None):
         if s is None:
             s = current_stream()
-        nccl_runtime_api.all_gather(
-            sendbuff, recvbuff, sendcount, int(dtype_to_nccl(datatype)), self._handle, s
-        )        
-    
+        nccl_runtime_api.all_gather(sendbuff, recvbuff, sendcount, int(dtype_to_nccl(datatype)), self._handle, s)
+
     def reduce_scatter(
         self, sendbuff: int, recvbuff: int, recvcount: int, datatype: DataType, op: int, s: Optional[Stream] = None
     ):
@@ -128,7 +124,6 @@ class NcclCommunicator:
         nccl_runtime_api.reduce_scatter(
             sendbuff, recvbuff, recvcount, int(dtype_to_nccl(datatype)), int(str_to_nccl_op(op)), self._handle, s
         )
-
 
 
 def create_comm(nranks: int, unique_id: NcclUniqueId, rank: int) -> NcclCommunicator:

--- a/python/hidet/cuda/nccl/ffi.py
+++ b/python/hidet/cuda/nccl/ffi.py
@@ -132,12 +132,39 @@ if nccl_available():
             assert ret == 0
             return comm.value
 
-        # TODO: Currently only support all_reduce
         @staticmethod
         def all_reduce(
             sendbuff: int, recvbuff: int, count: int, datatype: int, op: int, comm_handle: int, s: Stream
         ) -> None:
             ret = NCCLRuntimeAPI._all_reduce(sendbuff, recvbuff, count, datatype, op, comm_handle, c_void_p(int(s)))
+            assert ret == 0
+
+        @staticmethod
+        def broadcast(
+            sendbuff: int, recvbuff: int, count: int, datatype: int, root: int, comm_handle: int, s: Stream
+        ) -> None:
+            ret = NCCLRuntimeAPI._broadcast(sendbuff, recvbuff, count, datatype, root, comm_handle, c_void_p(int(s)))
+            assert ret == 0
+
+        @staticmethod
+        def reduce(
+            sendbuff: int, recvbuff: int, count: int, datatype: int, op: int, root: int, comm_handle: int, s: Stream
+        ) -> None:
+            ret = NCCLRuntimeAPI._reduce(sendbuff, recvbuff, count, datatype, op, root, comm_handle, c_void_p(int(s)))
+            assert ret == 0
+        
+        @staticmethod
+        def all_gather(
+            sendbuff: int, recvbuff: int, sendcount: int, datatype: int, comm_handle: int, s: Stream
+        ) -> None:
+            ret = NCCLRuntimeAPI._all_gather(sendbuff, recvbuff, sendcount, datatype, comm_handle, c_void_p(int(s)))
+            assert ret == 0
+
+        @staticmethod
+        def reduce_scatter(
+            sendbuff: int, recvbuff: int, recvcount: int, datatype: int, op: int, comm_handle: int, s: Stream
+        ) -> None:
+            ret = NCCLRuntimeAPI._reduce_scatter(sendbuff, recvbuff, recvcount, datatype, op, comm_handle, c_void_p(int(s)))
             assert ret == 0
 
     nccl_runtime_api = NCCLRuntimeAPI()

--- a/python/hidet/cuda/nccl/ffi.py
+++ b/python/hidet/cuda/nccl/ffi.py
@@ -152,7 +152,7 @@ if nccl_available():
         ) -> None:
             ret = NCCLRuntimeAPI._reduce(sendbuff, recvbuff, count, datatype, op, root, comm_handle, c_void_p(int(s)))
             assert ret == 0
-        
+
         @staticmethod
         def all_gather(
             sendbuff: int, recvbuff: int, sendcount: int, datatype: int, comm_handle: int, s: Stream
@@ -164,7 +164,9 @@ if nccl_available():
         def reduce_scatter(
             sendbuff: int, recvbuff: int, recvcount: int, datatype: int, op: int, comm_handle: int, s: Stream
         ) -> None:
-            ret = NCCLRuntimeAPI._reduce_scatter(sendbuff, recvbuff, recvcount, datatype, op, comm_handle, c_void_p(int(s)))
+            ret = NCCLRuntimeAPI._reduce_scatter(
+                sendbuff, recvbuff, recvcount, datatype, op, comm_handle, c_void_p(int(s))
+            )
             assert ret == 0
 
     nccl_runtime_api = NCCLRuntimeAPI()

--- a/python/hidet/cuda/nccl/ffi.py
+++ b/python/hidet/cuda/nccl/ffi.py
@@ -91,19 +91,11 @@ if nccl_available():
             'ncclReduceScatter', [c_void_p, c_void_p, c_uint64, c_int, c_int, c_void_p, c_void_p], c_int, lib=_LIB_NCCL
         )
 
-        _send = get_func(
-            'ncclSend', [c_void_p, c_uint64, c_int, c_int, c_void_p, c_void_p], c_int, lib=_LIB_NCCL
-        )
-        _recv = get_func(
-            'ncclRecv', [c_void_p, c_uint64, c_int, c_int, c_void_p, c_void_p], c_int, lib=_LIB_NCCL
-        )
+        _send = get_func('ncclSend', [c_void_p, c_uint64, c_int, c_int, c_void_p, c_void_p], c_int, lib=_LIB_NCCL)
+        _recv = get_func('ncclRecv', [c_void_p, c_uint64, c_int, c_int, c_void_p, c_void_p], c_int, lib=_LIB_NCCL)
 
-        _group_start = get_func(
-            'ncclGroupStart', [], c_int, lib=_LIB_NCCL
-        )
-        _group_end = get_func(
-            'ncclGroupEnd', [], c_int, lib=_LIB_NCCL
-        )
+        _group_start = get_func('ncclGroupStart', [], c_int, lib=_LIB_NCCL)
+        _group_end = get_func('ncclGroupEnd', [], c_int, lib=_LIB_NCCL)
 
         # Early versions of NCCL do not have split
         try:
@@ -182,30 +174,21 @@ if nccl_available():
                 sendbuff, recvbuff, recvcount, datatype, op, comm_handle, c_void_p(int(s))
             )
             assert ret == 0
-        
+
         @staticmethod
-        def send(
-            sendbuff:int, count: int, datatype: int, peer: int, comm_handle: int, s: Stream
-        ) -> None:
-            ret = NCCLRuntimeAPI._send(
-                sendbuff, count, datatype, peer, comm_handle, c_void_p(int(s)) 
-            )
-            assert ret == 0 
-        
+        def send(sendbuff: int, count: int, datatype: int, peer: int, comm_handle: int, s: Stream) -> None:
+            ret = NCCLRuntimeAPI._send(sendbuff, count, datatype, peer, comm_handle, c_void_p(int(s)))
+            assert ret == 0, ret
+
         @staticmethod
-        def recv(
-            recvbuff:int, count: int, datatype: int, peer: int, comm_handle: int, s: Stream
-        ) -> None:
-            ret = NCCLRuntimeAPI._send(
-                recvbuff, count, datatype, peer, comm_handle, c_void_p(int(s)) 
-            )
-            assert ret == 0 
-        
+        def recv(recvbuff: int, count: int, datatype: int, peer: int, comm_handle: int, s: Stream) -> None:
+            ret = NCCLRuntimeAPI._recv(recvbuff, count, datatype, peer, comm_handle, c_void_p(int(s)))
+            assert ret == 0, ret
+
         @staticmethod
         def group_start() -> None:
             ret = NCCLRuntimeAPI._group_start()
             assert ret == 0
-        
 
         @staticmethod
         def group_end() -> None:
@@ -216,6 +199,6 @@ if nccl_available():
 
     def group_start():
         nccl_runtime_api.group_start()
-    
+
     def group_end():
         nccl_runtime_api.group_end()

--- a/python/hidet/cuda/nccl/ffi.py
+++ b/python/hidet/cuda/nccl/ffi.py
@@ -91,6 +91,20 @@ if nccl_available():
             'ncclReduceScatter', [c_void_p, c_void_p, c_uint64, c_int, c_int, c_void_p, c_void_p], c_int, lib=_LIB_NCCL
         )
 
+        _send = get_func(
+            'ncclSend', [c_void_p, c_uint64, c_int, c_int, c_void_p, c_void_p], c_int, lib=_LIB_NCCL
+        )
+        _recv = get_func(
+            'ncclRecv', [c_void_p, c_uint64, c_int, c_int, c_void_p, c_void_p], c_int, lib=_LIB_NCCL
+        )
+
+        _group_start = get_func(
+            'ncclGroupStart', [], c_int, lib=_LIB_NCCL
+        )
+        _group_end = get_func(
+            'ncclGroupEnd', [], c_int, lib=_LIB_NCCL
+        )
+
         # Early versions of NCCL do not have split
         try:
             _comm_split = get_func('ncclCommSplit', [c_void_p, c_int, c_int, c_void_p, c_void_p], c_int, lib=_LIB_NCCL)
@@ -168,5 +182,40 @@ if nccl_available():
                 sendbuff, recvbuff, recvcount, datatype, op, comm_handle, c_void_p(int(s))
             )
             assert ret == 0
+        
+        @staticmethod
+        def send(
+            sendbuff:int, count: int, datatype: int, peer: int, comm_handle: int, s: Stream
+        ) -> None:
+            ret = NCCLRuntimeAPI._send(
+                sendbuff, count, datatype, peer, comm_handle, c_void_p(int(s)) 
+            )
+            assert ret == 0 
+        
+        @staticmethod
+        def recv(
+            recvbuff:int, count: int, datatype: int, peer: int, comm_handle: int, s: Stream
+        ) -> None:
+            ret = NCCLRuntimeAPI._send(
+                recvbuff, count, datatype, peer, comm_handle, c_void_p(int(s)) 
+            )
+            assert ret == 0 
+        
+        @staticmethod
+        def group_start() -> None:
+            ret = NCCLRuntimeAPI._group_start()
+            assert ret == 0
+        
+
+        @staticmethod
+        def group_end() -> None:
+            ret = NCCLRuntimeAPI._group_end()
+            assert ret == 0
 
     nccl_runtime_api = NCCLRuntimeAPI()
+
+    def group_start():
+        nccl_runtime_api.group_start()
+    
+    def group_end():
+        nccl_runtime_api.group_end()

--- a/python/hidet/distributed/__init__.py
+++ b/python/hidet/distributed/__init__.py
@@ -10,6 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .distributed import init_process_group, all_reduce, broadcast, reduce, all_gather_into_tensor
+from .distributed import init_process_group, all_reduce, broadcast, reduce, all_gather_into_tensor, reduce_scatter_tensor, barrier
 from .group import set_nccl_comms
 from .store import FileStore

--- a/python/hidet/distributed/__init__.py
+++ b/python/hidet/distributed/__init__.py
@@ -19,6 +19,7 @@ from .distributed import (
     all_gather_into_tensor,
     gather,
     scatter,
+    reduce_scatter,
     reduce_scatter_tensor,
     barrier,
     send,

--- a/python/hidet/distributed/__init__.py
+++ b/python/hidet/distributed/__init__.py
@@ -10,6 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .distributed import init_process_group, all_reduce, broadcast, reduce
+from .distributed import init_process_group, all_reduce, broadcast, reduce, all_gather_into_tensor
 from .group import set_nccl_comms
 from .store import FileStore

--- a/python/hidet/distributed/__init__.py
+++ b/python/hidet/distributed/__init__.py
@@ -15,9 +15,14 @@ from .distributed import (
     all_reduce,
     broadcast,
     reduce,
+    all_gather,
     all_gather_into_tensor,
+    gather,
+    scatter,
     reduce_scatter_tensor,
     barrier,
+    send,
+    recv,
 )
 from .group import set_nccl_comms
 from .store import FileStore

--- a/python/hidet/distributed/__init__.py
+++ b/python/hidet/distributed/__init__.py
@@ -10,6 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .distributed import init_process_group, all_reduce
+from .distributed import init_process_group, all_reduce, broadcast, reduce
 from .group import set_nccl_comms
 from .store import FileStore

--- a/python/hidet/distributed/__init__.py
+++ b/python/hidet/distributed/__init__.py
@@ -10,6 +10,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .distributed import init_process_group, all_reduce, broadcast, reduce, all_gather_into_tensor, reduce_scatter_tensor, barrier
+from .distributed import (
+    init_process_group,
+    all_reduce,
+    broadcast,
+    reduce,
+    all_gather_into_tensor,
+    reduce_scatter_tensor,
+    barrier,
+)
 from .group import set_nccl_comms
 from .store import FileStore

--- a/python/hidet/distributed/distributed.py
+++ b/python/hidet/distributed/distributed.py
@@ -93,6 +93,7 @@ def broadcast(tensor: Tensor, src: int, group=None):
         group = DEFAULT_GROUP
     group.broadcast(tensor, src)
 
+
 def all_reduce(tensor: Tensor, op: str, group: Optional[ProcessGroup] = None):
     if group is None:
         group = DEFAULT_GROUP
@@ -110,13 +111,16 @@ def all_gather_into_tensor(output_tensor: Tensor, input_tensor: Tensor, group: O
         group = DEFAULT_GROUP
     group.all_gather_into_tensor(output_tensor, input_tensor)
 
+
 def scatter():
     raise NotImplementedError()
+
 
 def reduce_scatter_tensor(output: Tensor, input: Tensor, op: str, group: Optional[ProcessGroup] = None):
     if group is None:
         group = DEFAULT_GROUP
     group.reduce_scatter_tensor(output, input, op)
+
 
 def barrier(group: Optional[ProcessGroup] = None):
     if group is None:

--- a/python/hidet/distributed/distributed.py
+++ b/python/hidet/distributed/distributed.py
@@ -94,6 +94,9 @@ def broadcast(tensor: Tensor, src: int, group=None):
         For the sender, the tensor to be broadcasted. 
         For other devices, the tensor to store the broadcasted data. It will be updated in-place.
     
+    src: int
+        The rank of the device that sends the data.
+    
     group: Optional[ProcessGroup]
         The process group to work on. If None, the default process group will be used.
     """
@@ -114,6 +117,9 @@ def all_reduce(tensor: Tensor, op: str, group: Optional[ProcessGroup] = None):
     tensor: Tensor
         The tensor to be reduced. It will be updated in-place.
     
+    op: str
+        The reduction operation, which can be 'sum', 'prod', 'max', 'min', 'avg'.
+    
     group: Optional[ProcessGroup]
         The process group to work on. If None, the default process group will be used.
     """
@@ -133,6 +139,9 @@ def reduce(tensor: Tensor, dst: int, op: str, group: Optional[ProcessGroup] = No
     ----------
     tensor: Tensor
         The input tensor to be reduced. The result will be stored in the tensor on the device with rank 'dst'. 
+
+    op: str
+        The reduction operation, which can be 'sum', 'prod', 'max', 'min', 'avg'.
 
     group: Optional[ProcessGroup]
         The process group to work on. If None, the default process group will be used.
@@ -213,8 +222,11 @@ def gather(
         The input tensor to be broadcasted to all devices.
 
     gather_list: Optional[List[Tensor]]
-        On the device st, a list of tensors where the result will be stored.
+        On the device dst, a list of tensors where the result will be stored.
         On other devices, it can be set as None.
+
+    dst: int
+        The rank of the device that gathers tensors
 
     group: Optional[ProcessGroup]
         The process group to work on. If None, the default process group will be used.
@@ -227,36 +239,147 @@ def gather(
 def scatter(
     tensor: Tensor, scatter_list: Optional[List[Tensor]] = None, src: int = 0, group: Optional[ProcessGroup] = None
 ):
+    """Scatter a list of tensors from the device 'src' to all devices .
+
+    scatter_list[i] from the device 'src' will be stored in 'tensor' on the i-th device.
+
+    .. tip::
+
+        The caller should make sure the metadata (shape, dtype) of scatter_list[i] from
+        the device 'src' is the same as tensor on the i-th device.
+
+    Parameters
+    ----------
+    tensor: Tensor
+        The tensor to store the received data.
+
+    scatter_list: Optional[List[Tensor]]
+        On the device src, a list of tensors to be scattered.
+        On other devices, it can be set as None.
+    
+    src: int
+        The rank of the device that sends data.
+
+    group: Optional[ProcessGroup]
+        The process group to work on. If None, the default process group will be used.
+    """
     if group is None:
         group = DEFAULT_GROUP
     group.scatter(tensor, scatter_list, src)
 
 
 def reduce_scatter(output: Tensor, input_list: List[Tensor], op: str, group: Optional[ProcessGroup] = None):
+    """Reduce each tensor in a list across all devices and store the result of each reduction on one device
+    
+    input_list[i] from all devices will be reduced and stored in the 'output' tensor on the i-th device. 
+
+    .. tip::
+
+        The caller should make sure the metadata (shape, dtype) of input_list[i] from all devices is the same,
+        and also same as the 'output' tensor on the i-th device.
+
+    Parameters
+    ----------
+    output: Tensor
+        The tensor to store the reduction result.
+
+    input_list: List[Tensor]
+        The input tensors to be reduced.
+
+    op: str
+        The reduction operation, which can be 'sum', 'prod', 'max', 'min', 'avg'.
+
+    group: Optional[ProcessGroup]
+        The process group to work on. If None, the default process group will be used.
+    """
     if group is None:
         group = DEFAULT_GROUP
     group.reduce_scatter(output, input_list, op)
 
 
 def reduce_scatter_tensor(output: Tensor, input: Tensor, op: str, group: Optional[ProcessGroup] = None):
+    """Reduce the input tensor across all devices and store a fraction of the result on each device
+    
+    input[i] from all devices will be reduced and stored in the 'output' tensor on the i-th device. 
+
+    .. tip::
+
+        The caller should make sure the metadata (shape, dtype) of input_list from all devices is the same,
+        and the 'output' tensor has the correct shape and dtype to store the reduction result.
+
+    Parameters
+    ----------
+    output: Tensor[dim_1, dim_2, ..., dim_n]
+        The tensor to store a fraction of the reduction result.
+
+    input: Tensor[world_size, dim_1, dim_2, ..., dim_n]
+        The input tensor to be reduced.
+
+    op: str
+        The reduction operation, which can be 'sum', 'prod', 'max', 'min', 'avg'.
+
+    group: Optional[ProcessGroup]
+        The process group to work on. If None, the default process group will be used.
+    """
     if group is None:
         group = DEFAULT_GROUP
     group.reduce_scatter_tensor(output, input, op)
 
 
 def barrier(group: Optional[ProcessGroup] = None):
+    """Synchonize all devices.
+
+    Parameters
+    ----------
+    group: Optional[ProcessGroup]
+        The process group to work on. If None, the default process group will be used.
+    """
     if group is None:
         group = DEFAULT_GROUP
     group.barrier()
 
 
 def send(tensor: Tensor, dst: int, group: Optional[ProcessGroup] = None):
+    """Send a tensor to the device dst.
+
+    .. tip::
+
+        The caller should make sure the metadata (shape, dtype) of tensor is the same on the sender and the receiver.
+
+    Parameters
+    ----------
+    tensor: Tensor
+        The tensor to be sent.
+    
+    dst: int
+        Rank of the device that data is sent to.
+
+    group: Optional[ProcessGroup]
+        The process group to work on. If None, the default process group will be used.
+    """
     if group is None:
         group = DEFAULT_GROUP
     group.send(tensor, dst)
 
 
 def recv(tensor: Tensor, src: int, group: Optional[ProcessGroup] = None):
+    """Receive a tensor from the device src.
+
+    .. tip::
+
+        The caller should make sure the metadata (shape, dtype) of tensor is the same on the sender and the receiver.
+
+    Parameters
+    ----------
+    tensor: Tensor
+        The tensor to store the received data.
+
+    src: int
+        Rank of the device that data is sent from.
+        
+    group: Optional[ProcessGroup]
+        The process group to work on. If None, the default process group will be used.
+    """
     if group is None:
         group = DEFAULT_GROUP
     group.recv(tensor, src)

--- a/python/hidet/distributed/distributed.py
+++ b/python/hidet/distributed/distributed.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, List
 from datetime import timedelta
 
 from hidet.graph import Tensor
@@ -106,14 +106,32 @@ def reduce(tensor: Tensor, dst: int, op: str, group: Optional[ProcessGroup] = No
     group.reduce(tensor, dst, op)
 
 
+def all_gather(tensor_list: List[Tensor], tensor: Tensor, group: Optional[ProcessGroup] = None):
+    if group is None:
+        group = DEFAULT_GROUP
+    group.all_gather(tensor_list, tensor)
+
+
 def all_gather_into_tensor(output_tensor: Tensor, input_tensor: Tensor, group: Optional[ProcessGroup] = None):
     if group is None:
         group = DEFAULT_GROUP
     group.all_gather_into_tensor(output_tensor, input_tensor)
 
 
-def scatter():
-    raise NotImplementedError()
+def gather(
+    tensor: Tensor, gather_list: Optional[List[Tensor]] = None, dst: int = 0, group: Optional[ProcessGroup] = None
+):
+    if group is None:
+        group = DEFAULT_GROUP
+    group.gather(tensor, gather_list, dst)
+
+
+def scatter(
+    tensor: Tensor, scatter_list: Optional[List[Tensor]] = None, src: int = 0, group: Optional[ProcessGroup] = None
+):
+    if group is None:
+        group = DEFAULT_GROUP
+    group.scatter(tensor, scatter_list, src)
 
 
 def reduce_scatter_tensor(output: Tensor, input: Tensor, op: str, group: Optional[ProcessGroup] = None):
@@ -126,3 +144,15 @@ def barrier(group: Optional[ProcessGroup] = None):
     if group is None:
         group = DEFAULT_GROUP
     group.barrier()
+
+
+def send(tensor: Tensor, dst: int, group: Optional[ProcessGroup] = None):
+    if group is None:
+        group = DEFAULT_GROUP
+    group.send(tensor, dst)
+
+
+def recv(tensor: Tensor, src: int, group: Optional[ProcessGroup] = None):
+    if group is None:
+        group = DEFAULT_GROUP
+    group.recv(tensor, src)

--- a/python/hidet/distributed/distributed.py
+++ b/python/hidet/distributed/distributed.py
@@ -113,6 +113,12 @@ def all_gather_into_tensor(output_tensor: Tensor, input_tensor: Tensor, group: O
 def scatter():
     raise NotImplementedError()
 
+def reduce_scatter_tensor(output: Tensor, input: Tensor, op: str, group: Optional[ProcessGroup] = None):
+    if group is None:
+        group = DEFAULT_GROUP
+    group.reduce_scatter_tensor(output, input, op)
 
-def reduce_scatter_tensor():
-    raise NotImplementedError()
+def barrier(group: Optional[ProcessGroup] = None):
+    if group is None:
+        group = DEFAULT_GROUP
+    group.barrier()

--- a/python/hidet/distributed/distributed.py
+++ b/python/hidet/distributed/distributed.py
@@ -79,9 +79,19 @@ def is_nccl_available():
     return nccl_available()
 
 
-def broadcast():
-    raise NotImplementedError()
+# The runtime API of collective communaction operations
+# Aligned with PyTorch, but different from Hidet ops
 
+
+def broadcast(tensor: Tensor, src: int, group=None):
+    """
+    The caller should make sure the metadata (shape, dtype) of the tensor is aligned with
+    the sender.
+    """
+    # TODO: support group
+    if group is None:
+        group = DEFAULT_GROUP
+    group.broadcast(tensor, src)
 
 def all_reduce(tensor: Tensor, op: str, group: Optional[ProcessGroup] = None):
     if group is None:
@@ -89,8 +99,10 @@ def all_reduce(tensor: Tensor, op: str, group: Optional[ProcessGroup] = None):
     group.all_reduce(tensor, op)
 
 
-def reduce():
-    raise NotImplementedError()
+def reduce(tensor: Tensor, dst: int, op: str, group: Optional[ProcessGroup] = None):
+    if group is None:
+        group = DEFAULT_GROUP
+    group.reduce(tensor, dst, op)
 
 
 def all_gather_into_tensor():

--- a/python/hidet/distributed/distributed.py
+++ b/python/hidet/distributed/distributed.py
@@ -134,6 +134,12 @@ def scatter(
     group.scatter(tensor, scatter_list, src)
 
 
+def reduce_scatter(output: Tensor, input_list: List[Tensor], op: str, group: Optional[ProcessGroup] = None):
+    if group is None:
+        group = DEFAULT_GROUP
+    group.reduce_scatter(output, input_list, op)
+
+
 def reduce_scatter_tensor(output: Tensor, input: Tensor, op: str, group: Optional[ProcessGroup] = None):
     if group is None:
         group = DEFAULT_GROUP

--- a/python/hidet/distributed/distributed.py
+++ b/python/hidet/distributed/distributed.py
@@ -105,9 +105,10 @@ def reduce(tensor: Tensor, dst: int, op: str, group: Optional[ProcessGroup] = No
     group.reduce(tensor, dst, op)
 
 
-def all_gather_into_tensor():
-    raise NotImplementedError()
-
+def all_gather_into_tensor(output_tensor: Tensor, input_tensor: Tensor, group: Optional[ProcessGroup] = None):
+    if group is None:
+        group = DEFAULT_GROUP
+    group.all_gather_into_tensor(output_tensor, input_tensor)
 
 def scatter():
     raise NotImplementedError()

--- a/python/hidet/distributed/distributed.py
+++ b/python/hidet/distributed/distributed.py
@@ -81,6 +81,7 @@ def is_nccl_available():
 
 # The runtime API of collective communaction operations is aligned with PyTorch
 
+
 def broadcast(tensor: Tensor, src: int, group=None):
     """Broadcast the tensor from device 'src' to all devices.
 
@@ -91,12 +92,12 @@ def broadcast(tensor: Tensor, src: int, group=None):
     Parameters
     ----------
     tensor: Tensor
-        For the sender, the tensor to be broadcasted. 
+        For the sender, the tensor to be broadcasted.
         For other devices, the tensor to store the broadcasted data. It will be updated in-place.
-    
+
     src: int
         The rank of the device that sends the data.
-    
+
     group: Optional[ProcessGroup]
         The process group to work on. If None, the default process group will be used.
     """
@@ -116,10 +117,10 @@ def all_reduce(tensor: Tensor, op: str, group: Optional[ProcessGroup] = None):
     ----------
     tensor: Tensor
         The tensor to be reduced. It will be updated in-place.
-    
+
     op: str
         The reduction operation, which can be 'sum', 'prod', 'max', 'min', 'avg'.
-    
+
     group: Optional[ProcessGroup]
         The process group to work on. If None, the default process group will be used.
     """
@@ -138,7 +139,7 @@ def reduce(tensor: Tensor, dst: int, op: str, group: Optional[ProcessGroup] = No
     Parameters
     ----------
     tensor: Tensor
-        The input tensor to be reduced. The result will be stored in the tensor on the device with rank 'dst'. 
+        The input tensor to be reduced. The result will be stored in the tensor on the device with rank 'dst'.
 
     op: str
         The reduction operation, which can be 'sum', 'prod', 'max', 'min', 'avg'.
@@ -158,7 +159,7 @@ def all_gather(tensor_list: List[Tensor], tensor: Tensor, group: Optional[Proces
 
     .. tip::
 
-        The caller should make sure the metadata (shape, dtype) of 'tensor' from the i-th device 
+        The caller should make sure the metadata (shape, dtype) of 'tensor' from the i-th device
         is the same as tensor_list[i] on all peers.
 
     Parameters
@@ -213,7 +214,7 @@ def gather(
 
     .. tip::
 
-        The caller should make sure the metadata (shape, dtype) of 'tensor' from the i-th device 
+        The caller should make sure the metadata (shape, dtype) of 'tensor' from the i-th device
         is the same as tensor_list[i] on the device dst.
 
     Parameters
@@ -256,7 +257,7 @@ def scatter(
     scatter_list: Optional[List[Tensor]]
         On the device src, a list of tensors to be scattered.
         On other devices, it can be set as None.
-    
+
     src: int
         The rank of the device that sends data.
 
@@ -270,8 +271,8 @@ def scatter(
 
 def reduce_scatter(output: Tensor, input_list: List[Tensor], op: str, group: Optional[ProcessGroup] = None):
     """Reduce each tensor in a list across all devices and store the result of each reduction on one device
-    
-    input_list[i] from all devices will be reduced and stored in the 'output' tensor on the i-th device. 
+
+    input_list[i] from all devices will be reduced and stored in the 'output' tensor on the i-th device.
 
     .. tip::
 
@@ -299,8 +300,8 @@ def reduce_scatter(output: Tensor, input_list: List[Tensor], op: str, group: Opt
 
 def reduce_scatter_tensor(output: Tensor, input: Tensor, op: str, group: Optional[ProcessGroup] = None):
     """Reduce the input tensor across all devices and store a fraction of the result on each device
-    
-    input[i] from all devices will be reduced and stored in the 'output' tensor on the i-th device. 
+
+    input[i] from all devices will be reduced and stored in the 'output' tensor on the i-th device.
 
     .. tip::
 
@@ -350,7 +351,7 @@ def send(tensor: Tensor, dst: int, group: Optional[ProcessGroup] = None):
     ----------
     tensor: Tensor
         The tensor to be sent.
-    
+
     dst: int
         Rank of the device that data is sent to.
 
@@ -376,7 +377,7 @@ def recv(tensor: Tensor, src: int, group: Optional[ProcessGroup] = None):
 
     src: int
         Rank of the device that data is sent from.
-        
+
     group: Optional[ProcessGroup]
         The process group to work on. If None, the default process group will be used.
     """

--- a/python/hidet/distributed/group.py
+++ b/python/hidet/distributed/group.py
@@ -98,10 +98,14 @@ class NCCLProcessGroup(ProcessGroup):
     def all_gather_into_tensor(self, output_tensor, input_tensor):
         assert not output_tensor.is_symbolic()
         assert not input_tensor.is_symbolic()
+        assert output_tensor.device.is_cuda()
+        assert input_tensor.device.is_cuda()
+
+        assert output_tensor.size == input_tensor.size * self._world_size
+
         output_addr = output_tensor.storage.addr
         input_addr = input_tensor.storage.addr
-        self._comm.all_gather(output_addr, input_addr, input_addr.size, input_tensor.dtype)
-        # TODO: shape check
+        self._comm.all_gather(output_addr, input_addr, input_tensor.size, input_tensor.dtype)
 
 
 def create_nccl_group(store: Store, world_size: int, rank: int):

--- a/python/hidet/distributed/group.py
+++ b/python/hidet/distributed/group.py
@@ -114,7 +114,7 @@ class NCCLProcessGroup(ProcessGroup):
     def all_gather(self, tensor_list: List[Tensor], tensor: Tensor):
         assert len(tensor_list) == self._world_size
         map(self._check_cuda_tensor, tensor_list)
-        assert self._check_cuda_tensor(tensor)
+        self._check_cuda_tensor(tensor)
 
         group_start()
         for i, recv_tensor in enumerate(tensor_list):

--- a/python/hidet/distributed/group.py
+++ b/python/hidet/distributed/group.py
@@ -17,7 +17,6 @@ from typing import Optional, List
 import hidet
 from hidet.graph import Tensor
 from hidet.cuda.nccl import create_unique_id, NcclUniqueId, create_comm, NcclCommunicator, comms_to_array
-from hidet.graph import Tensor
 from .store import Store
 
 
@@ -90,13 +89,13 @@ class NCCLProcessGroup(ProcessGroup):
         assert tensor.device.is_cuda()
         addr = tensor.storage.addr
         self._comm.broadcast(addr, addr, tensor.size, tensor.dtype, src)
-    
+
     def reduce(self, tensor: Tensor, dst: int, op: str):
         assert not tensor.is_symbolic()
         assert tensor.device.is_cuda()
         addr = tensor.storage.addr
         self._comm.reduce(addr, addr, tensor.size, tensor.dtype, op, dst)
-    
+
     def all_gather_into_tensor(self, output_tensor: Tensor, input_tensor: Tensor):
         assert not output_tensor.is_symbolic()
         assert not input_tensor.is_symbolic()
@@ -108,7 +107,7 @@ class NCCLProcessGroup(ProcessGroup):
         output_addr = output_tensor.storage.addr
         input_addr = input_tensor.storage.addr
         self._comm.all_gather(input_addr, output_addr, input_tensor.size, input_tensor.dtype)
-    
+
     def reduce_scatter_tensor(self, output: Tensor, input: Tensor, op: str):
         assert not output.is_symbolic()
         assert not input.is_symbolic()
@@ -119,7 +118,7 @@ class NCCLProcessGroup(ProcessGroup):
         output_addr = output.storage.addr
         input_addr = input.storage.addr
         self._comm.reduce_scatter(input_addr, output_addr, output.size, output.dtype, op)
-    
+
     def barrier(self):
         dummy_tensor = hidet.empty([], device='cuda')
         self.all_reduce(dummy_tensor, 'sum')

--- a/python/hidet/distributed/group.py
+++ b/python/hidet/distributed/group.py
@@ -83,6 +83,26 @@ class NCCLProcessGroup(ProcessGroup):
         addr = tensor.storage.addr
         self._comm.all_reduce(addr, addr, tensor.size, tensor.dtype, op)
 
+    def broadcast(self, tensor: Tensor, src: int):
+        assert not tensor.is_symbolic()
+        assert tensor.device.is_cuda()
+        addr = tensor.storage.addr
+        self._comm.broadcast(addr, addr, tensor.size, tensor.dtype, src)
+    
+    def reduce(self, tensor: Tensor, dst: int, op: str):
+        assert not tensor.is_symbolic()
+        assert tensor.device.is_cuda()
+        addr = tensor.storage.addr
+        self._comm.reduce(addr, addr, tensor.size, tensor.dtype, op, dst)
+    
+    def all_gather_into_tensor(self, output_tensor, input_tensor):
+        assert not output_tensor.is_symbolic()
+        assert not input_tensor.is_symbolic()
+        output_addr = output_tensor.storage.addr
+        input_addr = input_tensor.storage.addr
+        self._comm.all_gather(output_addr, input_addr, input_addr.size, input_tensor.dtype)
+        # TODO: shape check
+
 
 def create_nccl_group(store: Store, world_size: int, rank: int):
     if rank == 0:

--- a/python/hidet/graph/ops/__init__.py
+++ b/python/hidet/graph/ops/__init__.py
@@ -53,6 +53,6 @@ from .transform import permute_dims
 from .fusion import fused_operator
 from .transfer import transfer
 from .special import barrier
-from .distributed import all_reduce
+from .distributed import all_reduce, all_gather, reduce_scatter
 
 from . import utils

--- a/python/hidet/graph/ops/distributed.py
+++ b/python/hidet/graph/ops/distributed.py
@@ -15,6 +15,7 @@ from hidet.ir.type import DataType
 from hidet.ir.expr import Expr
 from hidet.ir.module import IRModule
 from hidet.ir.task import Target
+from hidet.ir.layout import RowMajorLayout
 from hidet.utils import prod
 from hidet.cuda.nccl import str_to_nccl_op
 from .utils import Task, TensorNode, Operator, Tensor, compute, input_like
@@ -22,11 +23,13 @@ from .utils import Task, TensorNode, Operator, Tensor, compute, input_like
 
 class AllReduceTask(Task):
     def __init__(self, x: TensorNode, op: str, comm_id: int = 0):
+        if not isinstance(x.type.layout, RowMajorLayout):
+            raise RuntimeError("Communication operations only support row major layout.")
         y = compute('out', x.shape, lambda *indices: x[indices])
         self.comm_id = comm_id
         self.op = op
 
-        super().__init__('all_reduce', inputs=[x], outputs=[y], attributes={'comm_id': comm_id, 'op': op})
+        super().__init__('distributed.all_reduce', inputs=[x], outputs=[y], attributes={'comm_id': comm_id, 'op': op})
 
     def implement(self, target: Union[Target, str], working_dir: str) -> List[IRModule]:
         import hidet
@@ -53,6 +56,76 @@ class AllReduceOp(Operator):
             inputs=[x], attributes={'op': op, 'comm_id': comm_id}, task=AllReduceTask(input_like(x, 'x'), op, comm_id)
         )
 
+class AllGatherTask(Task):
+    def __init__(self, x: TensorNode, nranks: int, comm_id: int = 0):
+        if not isinstance(x.type.layout, RowMajorLayout):
+            raise RuntimeError("Communication operations only support row major layout.")
+        y = compute('out', (nranks, ) + tuple(x.shape), lambda *indices: x[indices[1:]])
+
+        self.nranks = nranks
+        self.comm_id = comm_id
+
+        super().__init__('distributed.all_gather', inputs=[x], outputs=[y], attributes={'nranks': nranks, 'comm_id': comm_id})
+    
+    def implement(self, target: Union[Target, str], working_dir: str) -> List[IRModule]:
+        import hidet
+        from hidet.ir.primitives.cuda.nccl import all_gather as _all_gather
+        from hidet.lang import attrs
+
+        dtype: DataType = self.inputs[0].type.dtype
+        shape: Tuple[Expr, ...] = self.inputs[0].shape
+        size = prod(shape)
+        out_shape = (self.nranks, ) + tuple(shape)
+
+        with hidet.script_module() as script_module:
+            @hidet.script
+            def launch(x: dtype[shape], y: dtype[out_shape]):
+                attrs.func_kind = 'public'
+                _all_gather(x, y, size, dtype, self.comm_id)
+
+        return [script_module.ir_module()]
+
+class AllGatherOp(Operator):
+    def __init__(self, x: Tensor, nranks:int , comm_id: int):
+        super().__init__(
+            inputs=[x], attributes={'nranks': nranks, 'comm_id': comm_id}, task=AllGatherTask(input_like(x, 'x'), nranks, comm_id)
+        )
+
+class ReduceScatterTask(Task):
+    def __init__(self, x: TensorNode, op: str, comm_id: int = 0):
+        if not isinstance(x.type.layout, RowMajorLayout):
+            raise RuntimeError("Communication operations only support row major layout.")
+        if len(x.shape) < 1:
+            raise ValueError("The number of dimensions of the input tensor must be positive."
+                             "And the first dimension should be equal to the world size.")
+        y = compute('out', x.shape[1:], lambda *indices: x[(0, ) + indices])
+        self.comm_id = comm_id
+        self.op = op
+
+        super().__init__('distributed.reduce_scatter', inputs=[x], outputs=[y], attributes={'comm_id': comm_id, 'op': op})
+    
+    def implement(self, target: Union[Target, str], working_dir: str) -> List[IRModule]:
+        import hidet
+        from hidet.ir.primitives.cuda.nccl import reduce_scatter as _reduce_scatter
+        from hidet.lang import attrs
+
+        dtype: DataType = self.inputs[0].type.dtype
+        shape: Tuple[Expr, ...] = self.inputs[0].shape
+        size = prod(shape[1:])
+
+        with hidet.script_module() as script_module:
+            @hidet.script
+            def launch(x: dtype[shape], y: dtype[shape[1:]]):
+                attrs.func_kind = 'public'
+                _reduce_scatter(x, y, size, dtype, str_to_nccl_op(self.op), self.comm_id)
+
+        return [script_module.ir_module()]
+
+class ReduceScatterOp(Operator):
+    def __init__(self, x: Tensor, op: str, comm_id: int):
+        super().__init__(
+            inputs=[x], attributes={'op': op, 'comm_id': comm_id}, task=ReduceScatterTask(input_like(x, 'x'), op, comm_id)
+        )
 
 def all_reduce(x: Tensor, op: str, comm_id: int = 0) -> Tensor:
     if x.device.kind != 'cuda':
@@ -60,26 +133,28 @@ def all_reduce(x: Tensor, op: str, comm_id: int = 0) -> Tensor:
     return AllReduceOp(x, op, comm_id).outputs[0]
 
 
-def broadcast(x: Tensor, root: int, comm_id: int = 0) -> Tensor:
-    raise NotImplementedError()
-
-
-def reduce(x: Tensor, root: int, op: str, comm_id: int = 0) -> Tensor:
-    raise NotImplementedError()
-
-
-def all_gather(x: Tensor, comm_id: int = 0) -> Tensor:
-    raise NotImplementedError()
+def all_gather(x: Tensor, nranks: int, comm_id: int = 0) -> Tensor:
+    if x.device.kind != 'cuda':
+        raise RuntimeError("NCCL only supports CUDA tensors")
+    return AllGatherOp(x, nranks, comm_id).outputs[0]
 
 
 def reduce_scatter(x: Tensor, op: str, comm_id: int = 0) -> Tensor:
-    raise NotImplementedError()
+    if x.device.kind != 'cuda':
+        raise RuntimeError("NCCL only supports CUDA tensors")
 
 
+# We haven't decided how to integrate asymmetric communication functions into computational graphs
+# When a tensor is sent to other peers, it should be added to the output. Otherwise it won't be traced
+# But which part should do this?
 def send(x: Tensor, peer: int, comm_id: int = 0) -> None:
     raise NotImplementedError()
 
-
-# Recv is a little bit tricky since we need to pass the metadata of the recv buffer
 def recv(peer: int, comm_id: int = 0) -> Tensor:
+    raise NotImplementedError()
+
+def broadcast(x: Tensor, root: int, comm_id: int = 0) -> Tensor:
+    raise NotImplementedError()
+
+def reduce(x: Tensor, root: int, op: str, comm_id: int = 0) -> Tensor:
     raise NotImplementedError()

--- a/python/hidet/graph/ops/distributed.py
+++ b/python/hidet/graph/ops/distributed.py
@@ -142,6 +142,7 @@ def all_gather(x: Tensor, nranks: int, comm_id: int = 0) -> Tensor:
 def reduce_scatter(x: Tensor, op: str, comm_id: int = 0) -> Tensor:
     if x.device.kind != 'cuda':
         raise RuntimeError("NCCL only supports CUDA tensors")
+    return ReduceScatterOp(x, op, comm_id).outputs[0]
 
 
 # We haven't decided how to integrate asymmetric communication functions into computational graphs

--- a/python/hidet/ir/primitives/cuda/nccl.py
+++ b/python/hidet/ir/primitives/cuda/nccl.py
@@ -84,16 +84,3 @@ def reduce_scatter(sendbuff: Expr, recvbuff: Expr, recvcount: Expr, dtype: DataT
         comm,
         get_cuda_stream(),
     )
-
-
-def send(sendbuff: Expr, count: Expr, dtype: DataType, peer: int, comm_id: int):
-    comm = get_nccl_comm(comm_id)
-    return BlackBoxStmt(
-        'ncclSend({}, {}, (ncclDataType_t){}, {}, (ncclComm_t){}, (cudaStream_t){});',
-        sendbuff,
-        count,
-        int(dtype_to_nccl(dtype)),
-        peer,
-        comm,
-        get_cuda_stream(),
-    )

--- a/python/hidet/ir/primitives/cuda/nccl.py
+++ b/python/hidet/ir/primitives/cuda/nccl.py
@@ -85,6 +85,7 @@ def reduce_scatter(sendbuff: Expr, recvbuff: Expr, recvcount: Expr, dtype: DataT
         get_cuda_stream(),
     )
 
+
 def send(sendbuff: Expr, count: Expr, dtype: DataType, peer: int, comm_id: int):
     comm = get_nccl_comm(comm_id)
     return BlackBoxStmt(
@@ -94,5 +95,5 @@ def send(sendbuff: Expr, count: Expr, dtype: DataType, peer: int, comm_id: int):
         int(dtype_to_nccl(dtype)),
         peer,
         comm,
-        get_cuda_stream()
+        get_cuda_stream(),
     )

--- a/python/hidet/ir/primitives/cuda/nccl.py
+++ b/python/hidet/ir/primitives/cuda/nccl.py
@@ -13,17 +13,13 @@ from hidet.ir.expr import Expr
 from hidet.ir.stmt import BlackBoxStmt
 from hidet.ir.type import DataType
 
-# TODO: we should not put nccl-related types here since hidet.cuda.nccl depends on
-#       the existence of nccl library?
 from hidet.cuda.nccl import NcclRedOp, dtype_to_nccl
-
+from hidet.ir.primitives.runtime import get_cuda_stream, get_nccl_comm
 
 def all_reduce(sendbuff: Expr, recvbuff: Expr, count: Expr, dtype: DataType, op: NcclRedOp, comm_id: int):
-    from hidet.ir.primitives.runtime import get_cuda_stream, get_nccl_comm
-
     comm = get_nccl_comm(comm_id)
     return BlackBoxStmt(
-        'ncclAllReduce({}, {}, {}, (ncclDataType_t){}, (ncclRedOp_t){}, ' '(ncclComm_t){}, (cudaStream_t){});',
+        'ncclAllReduce({}, {}, {}, (ncclDataType_t){}, (ncclRedOp_t){}, (ncclComm_t){}, (cudaStream_t){});',
         sendbuff,
         recvbuff,
         count,
@@ -31,4 +27,54 @@ def all_reduce(sendbuff: Expr, recvbuff: Expr, count: Expr, dtype: DataType, op:
         int(op),
         comm,
         get_cuda_stream(),
+    )
+
+def broadcast(sendbuff: Expr, recvbuff: Expr, count: Expr, dtype: DataType, root: Expr, comm_id: int):
+    comm = get_nccl_comm(comm_id)
+    return BlackBoxStmt(
+        'ncclBroadcast({}, {}, {}, (ncclDataType_t){}, {}, (ncclComm_t){}, (cudaStream_t){});',
+        sendbuff,
+        recvbuff,
+        int(dtype_to_nccl(dtype)),
+        root,
+        comm,
+        get_cuda_stream()
+    )
+
+def reduce(sendbuff: Expr, recvbuff: Expr, count: Expr, dtype: DataType, op: NcclRedOp, root: Expr, comm_id: int):
+    comm = get_nccl_comm(comm_id)
+    return BlackBoxStmt(
+        'ncclReduce({}, {}, (ncclDataType_t){}, {}, {}, (ncclComm_t){}, (cudaStream_t){});',
+        sendbuff,
+        recvbuff,
+        int(dtype_to_nccl(dtype)),
+        int(op),
+        root,
+        comm,
+        get_cuda_stream()
+    )
+
+def all_gather(sendbuff: Expr, recvbuff: Expr, sendcount: Expr, dtype: DataType, comm_id:int):
+    comm = get_nccl_comm(comm_id)
+    return BlackBoxStmt(
+        'ncclAllGather({}, {}, {}, (ncclDataType_t){}, (ncclComm_t){}, (cudaStream_t){});',
+        sendbuff,
+        recvbuff,
+        sendcount,
+        int(dtype_to_nccl(dtype)),
+        comm,
+        get_cuda_stream()
+    )
+
+def reduce_scatter(sendbuff: Expr, recvbuff: Expr, recvcount: Expr, dtype: DataType, op: NcclRedOp, comm_id: int):
+    comm = get_nccl_comm(comm_id)
+    return BlackBoxStmt(
+        'ncclReduceScatter({}, {}, {}, (ncclDataType_t){}, (ncclRedOp_t){}, (ncclComm_t){}, (cudaStream_t){});',
+        sendbuff,
+        recvbuff,
+        recvcount,
+        int(dtype_to_nccl(dtype)),
+        int(op),
+        comm,
+        get_cuda_stream() 
     )

--- a/tests/distributed/test_op.py
+++ b/tests/distributed/test_op.py
@@ -23,9 +23,11 @@ import hidet.distributed
 
 TMP_PATH = './tmp'
 
+
 def test_all_reduce():
     if os.path.exists(TMP_PATH):
         os.remove(TMP_PATH)
+
     def foo(i):
         device = f'cuda:{i}'
         hidet.cuda.set_device(i)
@@ -35,15 +37,18 @@ def test_all_reduce():
         y = hidet.ops.all_reduce(x, 'avg')
         assert x.shape == y.shape
         assert all(y.cpu().numpy() == 0.5)
-    processes = [Process(target=foo, args=(i, )) for i in range(2)]
+
+    processes = [Process(target=foo, args=(i,)) for i in range(2)]
     for p in processes:
         p.start()
     for p in processes:
         p.join()
 
+
 def test_all_gather():
     if os.path.exists(TMP_PATH):
         os.remove(TMP_PATH)
+
     def foo(i):
         device = f'cuda:{i}'
         hidet.cuda.set_device(i)
@@ -51,16 +56,19 @@ def test_all_gather():
         hidet.distributed.set_nccl_comms()
         x = hidet.ones([4], device=device) * i
         y = hidet.ops.all_gather(x, 2)
-        assert numpy.array_equal(y.cpu().numpy(), [[0, 0, 0, 0],[1, 1, 1, 1]])
-    processes = [Process(target=foo, args=(i, )) for i in range(2)]
+        assert numpy.array_equal(y.cpu().numpy(), [[0, 0, 0, 0], [1, 1, 1, 1]])
+
+    processes = [Process(target=foo, args=(i,)) for i in range(2)]
     for p in processes:
         p.start()
     for p in processes:
         p.join()
 
+
 def test_reduce_scatter():
     if os.path.exists(TMP_PATH):
         os.remove(TMP_PATH)
+
     def foo(i):
         device = f'cuda:{i}'
         hidet.cuda.set_device(i)
@@ -69,11 +77,13 @@ def test_reduce_scatter():
         x = hidet.ones([2, 2], device=device) * i
         y = hidet.ops.reduce_scatter(x, 'sum')
         assert numpy.array_equal(y.cpu().numpy(), [1, 1])
-    processes = [Process(target=foo, args=(i, )) for i in range(2)]
+
+    processes = [Process(target=foo, args=(i,)) for i in range(2)]
     for p in processes:
         p.start()
     for p in processes:
         p.join()
+
 
 if __name__ == '__main__':
     test_all_reduce()

--- a/tests/distributed/test_op.py
+++ b/tests/distributed/test_op.py
@@ -23,12 +23,14 @@ import hidet.distributed
 
 from utils import distributed_test
 
+
 @distributed_test(world_size=2)
 def test_all_reduce(rank):
     x = hidet.ones([4], device='cuda') * rank
     y = hidet.ops.all_reduce(x, 'avg')
     assert x.shape == y.shape
     assert all(y.cpu().numpy() == 0.5)
+
 
 @distributed_test(world_size=2)
 def test_all_gather(rank):

--- a/tests/distributed/test_op.py
+++ b/tests/distributed/test_op.py
@@ -1,0 +1,63 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import multiprocessing
+from multiprocessing import Process
+import os
+import time
+from datetime import timedelta
+import random
+import numpy
+
+import hidet
+import hidet.distributed
+
+TMP_PATH = './tmp'
+
+def test_all_reduce():
+    if os.path.exists(TMP_PATH):
+        os.remove(TMP_PATH)
+    def foo(i):
+        device = f'cuda:{i}'
+        hidet.cuda.set_device(i)
+        hidet.distributed.init_process_group(init_method=f'file://{TMP_PATH}', world_size=2, rank=i)
+        hidet.distributed.set_nccl_comms()
+        x = hidet.ones([4], device=device) * i
+        y = hidet.ops.all_reduce(x, 'avg')
+        assert x.shape == y.shape
+        assert all(y.cpu().numpy() == 0.5)
+    processes = [Process(target=foo, args=(i, )) for i in range(2)]
+    for p in processes:
+        p.start()
+    for p in processes:
+        p.join()
+
+def test_all_gather():
+    if os.path.exists(TMP_PATH):
+        os.remove(TMP_PATH)
+    def foo(i):
+        device = f'cuda:{i}'
+        hidet.cuda.set_device(i)
+        hidet.distributed.init_process_group(init_method=f'file://{TMP_PATH}', world_size=2, rank=i)
+        hidet.distributed.set_nccl_comms()
+        x = hidet.ones([4], device=device) * i
+        y = hidet.ops.all_gather(x, 2)
+        assert numpy.array_equal(y.cpu().numpy(), [[0, 0, 0, 0],[1, 1, 1, 1]])
+    processes = [Process(target=foo, args=(i, )) for i in range(2)]
+    for p in processes:
+        p.start()
+    for p in processes:
+        p.join()
+
+if __name__ == '__main__':
+    test_all_reduce()
+    test_all_gather()

--- a/tests/distributed/test_runtime.py
+++ b/tests/distributed/test_runtime.py
@@ -75,7 +75,7 @@ def test_all_gather_into_tensor(rank):
     y = hidet.empty([2, 4], device='cuda')
     hidet.distributed.all_gather_into_tensor(y, x)
     hidet.cuda.synchronize()
-    assert numpy.array_equal(y.cpu().numpy(), [[1, 1, 1, 1], [0, 0, 0, 0]])
+    assert numpy.array_equal(y.cpu().numpy(), [[0, 0, 0, 0], [1, 1, 1, 1]])
 
 
 @distributed_test(world_size=WORLD_SIZE)
@@ -164,14 +164,14 @@ def test_send_recv(rank):
 
 
 if __name__ == '__main__':
-    # test_all_reduce()
-    # test_broadcast()
-    # test_reduce()
-    # test_all_gather()
-    # test_gather()
-    # test_scatter()
-    # test_all_gather_into_tensor()
+    test_all_reduce()
+    test_broadcast()
+    test_reduce()
+    test_all_gather()
+    test_gather()
+    test_scatter()
+    test_all_gather_into_tensor()
     test_reduce_scatter()
-    # test_reduce_scatter_tensor()
-    # test_barrier()
-    # test_send_recv()
+    test_reduce_scatter_tensor()
+    test_barrier()
+    test_send_recv()

--- a/tests/distributed/test_runtime.py
+++ b/tests/distributed/test_runtime.py
@@ -113,6 +113,23 @@ def test_scatter(rank):
 
 
 @distributed_test(world_size=WORLD_SIZE)
+def test_reduce_scatter(rank):
+    if rank == 0:
+        x = hidet.asarray([1, 2, 3], device='cuda', dtype=hidet.float32)
+        y = hidet.asarray([3, 4], device='cuda', dtype=hidet.float32)
+        o = hidet.empty([3], device='cuda')
+        hidet.distributed.reduce_scatter(o, [x, y], 'sum')
+        assert numpy.array_equal(o.cpu().numpy(), [6, 8, 10])
+    elif rank == 1:
+        x = hidet.asarray([5, 6, 7], device='cuda', dtype=hidet.float32)
+        y = hidet.asarray([7, 8], device='cuda', dtype=hidet.float32)
+        o = hidet.empty([2], device='cuda')
+        hidet.distributed.reduce_scatter(o, [x, y], 'sum')
+        hidet.cuda.synchronize()
+        assert numpy.array_equal(o.cpu().numpy(), [10, 12])
+
+
+@distributed_test(world_size=WORLD_SIZE)
 def test_reduce_scatter_tensor(rank):
     if rank == 0:
         x = hidet.asarray([[1, 2], [3, 4]], device='cuda', dtype=hidet.float32)
@@ -152,8 +169,9 @@ if __name__ == '__main__':
     # test_reduce()
     # test_all_gather()
     # test_gather()
-    test_scatter()
+    # test_scatter()
     # test_all_gather_into_tensor()
+    test_reduce_scatter()
     # test_reduce_scatter_tensor()
     # test_barrier()
-    test_send_recv()
+    # test_send_recv()

--- a/tests/distributed/test_runtime.py
+++ b/tests/distributed/test_runtime.py
@@ -28,6 +28,7 @@ TMP_PATH = './tmp'
 # This testing script assumes we have two GPUs.
 WORLD_SIZE = 2
 
+
 @distributed_test(world_size=WORLD_SIZE)
 def test_all_reduce(rank):
     x = hidet.ones([4], device='cuda') * rank
@@ -35,12 +36,14 @@ def test_all_reduce(rank):
     hidet.cuda.synchronize()
     assert all(x.cpu().numpy() == 0.5)
 
+
 @distributed_test(world_size=WORLD_SIZE)
 def test_broadcast(rank):
     x = hidet.ones([4], device='cuda') * rank
     hidet.distributed.broadcast(x, 1)
     hidet.cuda.synchronize()
     assert numpy.array_equal(x.cpu().numpy(), [1, 1, 1, 1])
+
 
 @distributed_test(world_size=WORLD_SIZE)
 def test_reduce(rank):
@@ -52,6 +55,7 @@ def test_reduce(rank):
     elif rank == 1:
         assert all(x.cpu().numpy() == 0.5)
 
+
 @distributed_test(world_size=WORLD_SIZE)
 def test_all_gather_into_tensor(rank):
     x = hidet.ones([4], device='cuda') * rank
@@ -59,6 +63,7 @@ def test_all_gather_into_tensor(rank):
     hidet.distributed.all_gather_into_tensor(y, x)
     hidet.cuda.synchronize()
     assert numpy.array_equal(y.cpu().numpy(), [[1, 1, 1, 1], [0, 0, 0, 0]])
+
 
 @distributed_test(world_size=WORLD_SIZE)
 def test_reduce_scatter(rank):
@@ -74,10 +79,12 @@ def test_reduce_scatter(rank):
     elif rank == 1:
         assert numpy.array_equal(y.cpu().numpy(), [10, 12])
 
+
 @distributed_test(world_size=WORLD_SIZE)
 def test_barrier(rank):
     hidet.distributed.barrier()
     hidet.cuda.synchronize()
+
 
 if __name__ == '__main__':
     # test_all_reduce()

--- a/tests/distributed/test_runtime.py
+++ b/tests/distributed/test_runtime.py
@@ -63,18 +63,26 @@ def test_all_gather_into_tensor(rank):
 @distributed_test(world_size=WORLD_SIZE)
 def test_reduce_scatter(rank):
     if rank == 0:
-        x = hidet.asarray([[1, 2], [3, 4]], device='cuda')
+        x = hidet.asarray([[1, 2], [3, 4]], device='cuda', dtype=hidet.float32)
     elif rank == 1:
-        x = hidet.asarray([[5, 6], [7, 8]], device='cuda')
-    y = hidet.distributed.reduce_scatter(x, 'sum')
+        x = hidet.asarray([[5, 6], [7, 8]], device='cuda', dtype=hidet.float32)
+    y = hidet.empty([2], device='cuda')
+    hidet.distributed.reduce_scatter_tensor(y, x, 'sum')
+    hidet.cuda.synchronize()
     if rank == 0:
         assert numpy.array_equal(y.cpu().numpy(), [6, 8])
     elif rank == 1:
         assert numpy.array_equal(y.cpu().numpy(), [10, 12])
 
+@distributed_test(world_size=WORLD_SIZE)
+def test_barrier(rank):
+    hidet.distributed.barrier()
+    hidet.cuda.synchronize()
+
 if __name__ == '__main__':
-    test_all_reduce()
-    test_broadcast()
-    test_reduce()
-    test_all_gather_into_tensor()
-    test_reduce_scatter()
+    # test_all_reduce()
+    # test_broadcast()
+    # test_reduce()
+    # test_all_gather_into_tensor()
+    # test_reduce_scatter()
+    test_barrier()

--- a/tests/distributed/utils.py
+++ b/tests/distributed/utils.py
@@ -2,11 +2,14 @@ import pytest
 import multiprocessing
 from multiprocessing import Process
 import os
+import pytest
 
 import hidet
 import hidet.distributed
 
 TMP_PATH = './tmp'
+
+
 def distributed_test(world_size):
     def decorator(func):
         def _f():
@@ -24,5 +27,7 @@ def distributed_test(world_size):
                 p.start()
             for p in processes:
                 p.join()
-        return _f
+
+        return pytest.mark.skip(reason='This test requires multiple GPUs')(_f)
+
     return decorator

--- a/tests/distributed/utils.py
+++ b/tests/distributed/utils.py
@@ -1,0 +1,28 @@
+import pytest
+import multiprocessing
+from multiprocessing import Process
+import os
+
+import hidet
+import hidet.distributed
+
+TMP_PATH = './tmp'
+def distributed_test(world_size):
+    def decorator(func):
+        def _f():
+            if os.path.exists(TMP_PATH):
+                os.remove(TMP_PATH)
+
+            def proc(i):
+                hidet.cuda.set_device(i)
+                hidet.distributed.init_process_group(init_method=f'file://{TMP_PATH}', world_size=world_size, rank=i)
+                hidet.distributed.set_nccl_comms()
+                func(i)
+
+            processes = [Process(target=proc, args=(i,)) for i in range(world_size)]
+            for p in processes:
+                p.start()
+            for p in processes:
+                p.join()
+        return _f
+    return decorator


### PR DESCRIPTION
We add the following communication functions related to distributed functionalities:

**Runtime API**

We mimic the APIs of  [PyTorch's distributed package](https://pytorch.org/docs/stable/distributed.html#collective-functions)

- all_reduce
- broadcast
- reduce
- all_gather
- all_gather_into_tensor
- gather
- scatter
- reduce_scatter
- reduce_scatter_tensor
- barrier
- send
- recv

**Hidet OPs**
- all_reduce
- all_gather
- reduce_scatter

We distinguish these two different usages of distributed primitives because many communication primitives cannot be directly viewed as nodes in computational graphs. 

Still working on documentation and comments