### PR TITLE
[Fixbug] Reduce should perform syncthread after initializing shared memory to zero

### DIFF
--- a/python/hidet/graph/ops/reduce/reduce.py
+++ b/python/hidet/graph/ops/reduce/reduce.py
@@ -168,6 +168,8 @@ class ReduceTask(Task):
                 rv = shfl_sync(mask, rv, 0, 32)
 
                 # write to staging area
+                if perform_atomic_reduce:
+                    syncthreads()
                 if threadIdx.x % 32 == 0:
                     if perform_atomic_reduce:
                         ro.atomic_combine(~smem_staging[0], cast(rv, accumulate_dtype))


### PR DESCRIPTION
This bug slipped through the CI because the test shapes were all too small. There is an initialization of shared memory that is not guarded by syncthread before others were able to access it.