### PR TITLE
[Fixbug] Fix the c++ standard to c++11 for both nvcc and gcc compilers

### DIFF
--- a/python/hidet/backend/build.py
+++ b/python/hidet/backend/build.py
@@ -147,6 +147,8 @@ class NVCC(SourceCompiler):
             '-O3',
             # host compiler options: enable openmp, avx2, unroll loops and fast math
             '-Xcompiler -fPIC,-m64,-O3,-funroll-loops,-ffast-math',
+            # use c++11 standard
+            '-std=c++11',
             # the target PTX and SASS version.
             '-gencode arch=compute_{cc},code=sm_{cc}'.format(cc=arch[len('sm_') :]),
             # allow ptxas (PTX assembler) to output information like register/smem usage.
@@ -223,6 +225,8 @@ class GCC(SourceCompiler):
             *['-l{}'.format(library) for library in linking_libs],
             # apply -O3 optimization.
             '-O3',
+            # use c++11 standard
+            '-std=c++11',
             # support avx intrinsics
             '-mavx2',
             '-m64',

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "click",
         "packaging",
         "requests",
+        "filelock",
         "cuda-python>=11.6.1; platform_system=='Linux'",
     ],
     platforms=["linux"],


### PR DESCRIPTION
1. Fix the nvcc and gcc compiler to use `-std=c++11` standard. This would allow hidet to work on some linux distribution with old version compiler (e.g., gcc 4.8.5 on centos7). See #326 
2. Add lockfile as the dependency of hidet. 