### PR TITLE
[Fixbug] Clear the intermediate object files for kernel tuning

### DIFF
--- a/python/hidet/drivers/build_task.py
+++ b/python/hidet/drivers/build_task.py
@@ -13,6 +13,7 @@ import logging
 import re
 import os
 import json
+import shutil
 from hashlib import sha256
 from typing import List, Optional, Tuple
 
@@ -161,6 +162,10 @@ def build_task_module(task: Task, candidates: List[IRModule], task_dir: str, tar
 
     # build task ir module
     build_ir_module(ir_module=task_ir_module, output_dir=task_dir, output_kind='.so', target=target)
+
+    # clear the candidate object files that are no longer needed
+    if not hidet.option.get_option('debug_cache_tuning'):
+        shutil.rmtree(os.path.join(task_dir, 'candidates'), ignore_errors=True)
 
 
 def generate_meta_data(task: Task, task_dir: str, build_target: str, num_candidates: int):


### PR DESCRIPTION
This PR clears the intermediate object files generated during tuning.

This should reduce 2/3 cache size without hurting any functionality. 

#338 