### PR TITLE
[Torch][Graph][Operator] Add and fix various items for torchvision model support

### DIFF
--- a/python/hidet/graph/frontend/torch/interpreter.py
+++ b/python/hidet/graph/frontend/torch/interpreter.py
@@ -358,11 +358,10 @@ class Interpreter:
                 hidet_args = load_arg(node.args, hidet_env)
                 hidet_kwargs = load_arg(node.kwargs, hidet_env)
                 try:
+                    hidet_env[node.name] = exec_func(*hidet_args, **hidet_kwargs)
                     from .register_functions import setitem
                     if exec_func.functions[0] is setitem:
-                        hidet_env[str(node.args[0])] = exec_func(*hidet_args, **hidet_kwargs)
-                    else:
-                        hidet_env[node.name] = exec_func(*hidet_args, **hidet_kwargs)
+                        hidet_env[str(node.args[0])] = hidet_env[node.name]
                 except Exception as e:
                     self._raise_exception(e, node.target, exec_func, hidet_args, hidet_kwargs)
             elif node.op == "call_method":
@@ -452,6 +451,9 @@ class Interpreter:
 
                 try:
                     hidet_env[node.name] = hidet_func(*hidet_args, **hidet_kwargs)
+                    from .register_functions import setitem
+                    if hidet_func.functions[0] is setitem:
+                        hidet_env[str(node.args[0])] = hidet_env[node.name]
                 except Exception as e:
                     self._raise_exception(e, node.target, hidet_func, hidet_args, hidet_kwargs)
 

--- a/python/hidet/graph/frontend/torch/interpreter.py
+++ b/python/hidet/graph/frontend/torch/interpreter.py
@@ -358,7 +358,11 @@ class Interpreter:
                 hidet_args = load_arg(node.args, hidet_env)
                 hidet_kwargs = load_arg(node.kwargs, hidet_env)
                 try:
-                    hidet_env[node.name] = exec_func(*hidet_args, **hidet_kwargs)
+                    from .register_functions import setitem
+                    if exec_func.functions[0] is setitem:
+                        hidet_env[str(node.args[0])] = exec_func(*hidet_args, **hidet_kwargs)
+                    else:
+                        hidet_env[node.name] = exec_func(*hidet_args, **hidet_kwargs)
                 except Exception as e:
                     self._raise_exception(e, node.target, exec_func, hidet_args, hidet_kwargs)
             elif node.op == "call_method":

--- a/python/hidet/graph/frontend/torch/interpreter.py
+++ b/python/hidet/graph/frontend/torch/interpreter.py
@@ -360,6 +360,7 @@ class Interpreter:
                 try:
                     hidet_env[node.name] = exec_func(*hidet_args, **hidet_kwargs)
                     from .register_functions import setitem
+
                     if exec_func.functions[0] is setitem:
                         hidet_env[str(node.args[0])] = hidet_env[node.name]
                 except Exception as e:
@@ -452,6 +453,7 @@ class Interpreter:
                 try:
                     hidet_env[node.name] = hidet_func(*hidet_args, **hidet_kwargs)
                     from .register_functions import setitem
+
                     if hidet_func.functions[0] is setitem:
                         hidet_env[str(node.args[0])] = hidet_env[node.name]
                 except Exception as e:

--- a/python/hidet/graph/frontend/torch/register_functions.py
+++ b/python/hidet/graph/frontend/torch/register_functions.py
@@ -20,7 +20,7 @@ from hidet.utils import same_list
 from hidet.ir.type import DataType
 from hidet.ir import expr
 from hidet.ir.dtypes import promote_type
-from hidet.ir.expr import Expr, Int, Constant, is_constant
+from hidet.ir.expr import Expr, Int, is_constant
 from hidet.runtime.device import Device
 from .interpreter import register_function, register_method
 from .interpreter import warnings
@@ -95,9 +95,11 @@ def conv3d_transpose(
 def adaptive_avg_pool2d(x: Tensor, output_size):
     return ops.adaptive_avg_pool2d(x, output_size)
 
+
 @register_function(torch.nn.functional.adaptive_avg_pool3d)
 def adaptive_avg_pool3d(x: Tensor, output_size):
     return ops.adaptive_avg_pool3d(x, output_size)
+
 
 @register_function(torch.nn.functional.relu)
 def relu(x: Tensor, inplace: bool):
@@ -233,6 +235,7 @@ def flatten(x: Tensor, start_dim: int, end_dim: int = -1):
 def getitem(x: Tensor, index):
     return x[index]
 
+
 @register_function(operator.setitem)
 def setitem(x: Tensor, item, setvalue):
 
@@ -268,9 +271,7 @@ def setitem(x: Tensor, item, setvalue):
             if v < 0:
                 v = v + x.shape[i]
             if is_constant(v, x.shape[i]) and (v < 0 or v >= x.shape[i]):
-                raise IndexError(
-                    'index {} is out of bound for dimension {} with size {}'.format(v, i, x.shape[i])
-                )
+                raise IndexError('index {} is out of bound for dimension {} with size {}'.format(v, i, x.shape[i]))
             normalized_item.append(v)
         elif v is not None:
             # None affects getitem, but is ignored in setitem
@@ -1010,6 +1011,7 @@ def ge(a: Union[Tensor, Expr, Number], b: Union[Tensor, Expr, Number]) -> Tensor
 def eq(a: Union[Tensor, Expr, Number], b: Union[Tensor, Expr, Number]) -> Tensor:
     if isinstance(a, Tensor) or isinstance(b, Tensor):
         from hidet.graph.ops.utils import convert_to_tensor
+
         if isinstance(a, Tensor):
             return ops.equal(a, convert_to_tensor(b, a))
         else:
@@ -1188,11 +1190,12 @@ def clamp(
 def isinf(x: Tensor) -> Tensor:
     return ops.isinf(x)
 @register_function(torch.nn.functional.pad)
-def pad(x: Tensor, pad: Union[Tuple[int], List[int]], mode: str = 'constant', value=0):
+def torch_pad(x: Tensor, pad: Union[Tuple[int], List[int]], mode: str = 'constant', value=0):
     if isinstance(pad, tuple):
         pad = list(pad)
     return ops.pad(x, pads=pad, mode=mode, value=value)
 
+
 @register_function(torch.roll)
-def roll(x: Tensor, shifts: Union[int, Sequence[int]], dims: Union[int, Sequence[int]] = None):
+def torch_roll(x: Tensor, shifts: Union[int, Sequence[int]], dims: Union[int, Sequence[int]] = None):
     return ops.roll(x, shifts, dims)

--- a/python/hidet/graph/frontend/torch/register_functions.py
+++ b/python/hidet/graph/frontend/torch/register_functions.py
@@ -133,7 +133,9 @@ def max_pool3d(x: Tensor, kernel_size, stride, padding=0, dilation=1, ceil_mode=
 
 
 @register_function(torch.nn.functional.linear)
-def linear(x: Tensor, weight: Tensor, bias: Optional[Tensor]):
+def linear(x: Tensor, weight: Tensor, bias: Optional[Tensor], weight_is_transposed=False):
+    if len(weight.shape) > 1 and not weight_is_transposed:
+        weight = ops.transpose(weight, [1, 0])
     y = ops.matmul(x, weight)
     if bias is not None:
         y = y + bias
@@ -1115,3 +1117,8 @@ def clamp(
 @register_function(torch.isinf)
 def isinf(x: Tensor) -> Tensor:
     return ops.isinf(x)
+@register_function(torch.nn.functional.pad)
+def pad(x: Tensor, pad: Union[Tuple[int], List[int]], mode: str = 'constant', value=0):
+    if isinstance(pad, tuple):
+        pad = list(pad)
+    return ops.pad(x, pads=pad, mode=mode, value=value)

--- a/python/hidet/graph/frontend/torch/register_functions.py
+++ b/python/hidet/graph/frontend/torch/register_functions.py
@@ -1189,6 +1189,8 @@ def clamp(
 @register_function(torch.isinf)
 def isinf(x: Tensor) -> Tensor:
     return ops.isinf(x)
+
+
 @register_function(torch.nn.functional.pad)
 def torch_pad(x: Tensor, pad: Union[Tuple[int], List[int]], mode: str = 'constant', value=0):
     if isinstance(pad, tuple):

--- a/python/hidet/graph/frontend/torch/register_functions.py
+++ b/python/hidet/graph/frontend/torch/register_functions.py
@@ -1195,5 +1195,4 @@ def pad(x: Tensor, pad: Union[Tuple[int], List[int]], mode: str = 'constant', va
 
 @register_function(torch.roll)
 def roll(x: Tensor, shifts: Union[int, Sequence[int]], dims: Union[int, Sequence[int]] = None):
-    print("in roll")
-    return x
+    return ops.roll(x, shifts, dims)

--- a/python/hidet/graph/frontend/torch/register_functions.py
+++ b/python/hidet/graph/frontend/torch/register_functions.py
@@ -96,6 +96,9 @@ def conv3d_transpose(
 def adaptive_avg_pool2d(x: Tensor, output_size):
     return ops.adaptive_avg_pool2d(x, output_size)
 
+@register_function(torch.nn.functional.adaptive_avg_pool3d)
+def adaptive_avg_pool3d(x: Tensor, output_size):
+    return ops.adaptive_avg_pool3d(x, output_size)
 
 @register_function(torch.nn.functional.relu)
 def relu(x: Tensor, inplace: bool):
@@ -205,10 +208,18 @@ def batch_norm(
         )
     y = ops.batch_norm_infer(x, running_mean, running_var, epsilon=eps)
     _ = momentum  # unused
+    if len(x.shape) == 3:
+        dims = [0, 2]
+    if len(x.shape) == 4:
+        dims = [0, 2, 3]
+    elif len(x.shape) == 5:
+        dims = [0, 2, 3, 4]
+    else:
+        raise NotImplementedError("batch_norm only accepts 3D, 4D, 5D input")
     if weight is not None:
-        y = y * weight.unsqueeze([0, 2, 3])
+        y = y * weight.unsqueeze(dims)
     if bias is not None:
-        y = y + bias.unsqueeze([0, 2, 3])
+        y = y + bias.unsqueeze(dims)
     return y
 
 

--- a/python/hidet/graph/frontend/torch/register_functions.py
+++ b/python/hidet/graph/frontend/torch/register_functions.py
@@ -949,6 +949,12 @@ def ge(a: Union[Tensor, Expr, Number], b: Union[Tensor, Expr, Number]) -> Tensor
 
 @register_function(operator.eq)
 def eq(a: Union[Tensor, Expr, Number], b: Union[Tensor, Expr, Number]) -> Tensor:
+    if isinstance(a, Tensor) or isinstance(b, Tensor):
+        from hidet.graph.ops.utils import convert_to_tensor
+        if isinstance(a, Tensor):
+            return ops.equal(a, convert_to_tensor(b, a))
+        else:
+            return ops.equal(b, convert_to_tensor(a, b))
     return a == b
 
 

--- a/python/hidet/graph/frontend/torch/register_functions.py
+++ b/python/hidet/graph/frontend/torch/register_functions.py
@@ -234,6 +234,11 @@ def flatten(x: Tensor, start_dim: int, end_dim: int = -1):
 def getitem(x: Tensor, index):
     return x[index]
 
+@register_function(operator.setitem)
+def setitem(x: Tensor, *args):
+    print("in setitem")
+    pass
+
 
 @register_function(operator.mul)
 @register_function(torch.mul)
@@ -1122,3 +1127,8 @@ def pad(x: Tensor, pad: Union[Tuple[int], List[int]], mode: str = 'constant', va
     if isinstance(pad, tuple):
         pad = list(pad)
     return ops.pad(x, pads=pad, mode=mode, value=value)
+
+@register_function(torch.roll)
+def roll(x: Tensor, shifts: Union[int, Sequence[int]], dims: Union[int, Sequence[int]] = None):
+    print("in roll")
+    return x

--- a/python/hidet/graph/frontend/torch/register_methods.py
+++ b/python/hidet/graph/frontend/torch/register_methods.py
@@ -265,3 +265,6 @@ def tensor_any(self: Tensor, dim=None, keepdim=False) -> Tensor:
 @register_method(torch.Tensor.all)
 def tensor_all(self: Tensor, dim=None, keepdim=False) -> Tensor:
     return ops.all(self, axis=dim, keepdims=keepdim)
+@register_method(torch.Tensor.matmul)
+def tensor_detach(self: Tensor, other: Tensor) -> Tensor:
+    return ops.matmul(self, other)

--- a/python/hidet/graph/frontend/torch/register_methods.py
+++ b/python/hidet/graph/frontend/torch/register_methods.py
@@ -268,3 +268,23 @@ def tensor_all(self: Tensor, dim=None, keepdim=False) -> Tensor:
 @register_method(torch.Tensor.matmul)
 def tensor_detach(self: Tensor, other: Tensor) -> Tensor:
     return ops.matmul(self, other)
+def tensor_matmul(self: Tensor, other: Tensor) -> Tensor:
+    return ops.matmul(self, other)
+
+@register_method(torch.Tensor.new_zeros)
+def tensor_new_zeros(self: Tensor, *size, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):
+    if layout is not None:
+        raise NotImplementedError("layout is not None")
+    if len(size) == 1:
+        if isinstance(size[0], (list, tuple)):
+            size = size[0]
+    shape = size
+    if dtype is None:
+        dtype = self.dtype
+    if device is None:
+        device = self.device
+
+    _ = pin_memory
+    _ = requires_grad
+
+    return ops.full(shape, dtype=dtype, device=device, value=dtype.zero)

--- a/python/hidet/graph/frontend/torch/register_methods.py
+++ b/python/hidet/graph/frontend/torch/register_methods.py
@@ -265,9 +265,9 @@ def tensor_any(self: Tensor, dim=None, keepdim=False) -> Tensor:
 @register_method(torch.Tensor.all)
 def tensor_all(self: Tensor, dim=None, keepdim=False) -> Tensor:
     return ops.all(self, axis=dim, keepdims=keepdim)
+
+
 @register_method(torch.Tensor.matmul)
-def tensor_detach(self: Tensor, other: Tensor) -> Tensor:
-    return ops.matmul(self, other)
 def tensor_matmul(self: Tensor, other: Tensor) -> Tensor:
     return ops.matmul(self, other)
 

--- a/python/hidet/graph/frontend/torch/register_methods.py
+++ b/python/hidet/graph/frontend/torch/register_methods.py
@@ -271,6 +271,7 @@ def tensor_detach(self: Tensor, other: Tensor) -> Tensor:
 def tensor_matmul(self: Tensor, other: Tensor) -> Tensor:
     return ops.matmul(self, other)
 
+
 @register_method(torch.Tensor.new_zeros)
 def tensor_new_zeros(self: Tensor, *size, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):
     if layout is not None:

--- a/python/hidet/graph/frontend/torch/register_modules.py
+++ b/python/hidet/graph/frontend/torch/register_modules.py
@@ -116,6 +116,11 @@ class HidetAdaptiveAvgPool2d(HidetModule):
         assert isinstance(self.mod, torch.nn.AdaptiveAvgPool2d)
         return regs.adaptive_avg_pool2d(x, self.mod.output_size)
 
+@register_module(torch.nn.AdaptiveAvgPool3d)
+class HidetAdaptiveAvgPool3d(HidetModule):
+    def __call__(self, x: Tensor) -> Tensor:
+        assert isinstance(self.mod, torch.nn.AdaptiveAvgPool3d)
+        return regs.adaptive_avg_pool3d(x, self.mod.output_size)
 
 @register_module(torch.nn.ReLU)
 class HidetReLU(HidetModule):
@@ -170,9 +175,10 @@ class HidetLinear(HidetModule):
 
 
 @register_module(torch.nn.BatchNorm2d)
+@register_module(torch.nn.BatchNorm3d)
 class HidetBatchNorm2d(HidetModule):
     def __call__(self, x: Tensor) -> Tensor:
-        assert isinstance(self.mod, torch.nn.BatchNorm2d)
+        assert isinstance(self.mod, (torch.nn.BatchNorm2d, torch.nn.BatchNorm3d))
         return regs.batch_norm(
             x=x,
             running_mean=self.param('running_mean'),

--- a/python/hidet/graph/frontend/torch/register_modules.py
+++ b/python/hidet/graph/frontend/torch/register_modules.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import torch
 from hidet.graph import ops
 from hidet.graph.tensor import Tensor
-from .interpreter import HidetModule, register_module, warnings
+from .interpreter import HidetModule, register_module
 from . import register_functions as regs
 from .dynamo_config import dynamo_config
 
@@ -117,11 +117,13 @@ class HidetAdaptiveAvgPool2d(HidetModule):
         assert isinstance(self.mod, torch.nn.AdaptiveAvgPool2d)
         return regs.adaptive_avg_pool2d(x, self.mod.output_size)
 
+
 @register_module(torch.nn.AdaptiveAvgPool3d)
 class HidetAdaptiveAvgPool3d(HidetModule):
     def __call__(self, x: Tensor) -> Tensor:
         assert isinstance(self.mod, torch.nn.AdaptiveAvgPool3d)
         return regs.adaptive_avg_pool3d(x, self.mod.output_size)
+
 
 @register_module(torch.nn.ReLU)
 class HidetReLU(HidetModule):
@@ -164,16 +166,14 @@ class HidetMaxPool3d(HidetModule):
 class HidetLinear(HidetModule):
     def __init__(self, torch_module: torch.nn.Module):
         super().__init__(torch_module)
-        from hidet import ops
-
         steal = dynamo_config['steal_weights']
-
         self.transposed_weight = ops.transpose(self.param('weight', steal=steal), [1, 0])
 
     def __call__(self, x: Tensor) -> Tensor:
         assert isinstance(self.mod, torch.nn.Linear)
-        return regs.linear(x=x, weight=self.transposed_weight,
-                           bias=self.param('bias', optional=True), weight_is_transposed=True)
+        return regs.linear(
+            x=x, weight=self.transposed_weight, bias=self.param('bias', optional=True), weight_is_transposed=True
+        )
 
 
 @register_module(torch.nn.BatchNorm2d)
@@ -413,36 +413,43 @@ class HidetUpsample(HidetModule):
             recompute_scale_factor=self.mod.recompute_scale_factor,
         )
 
+
 @register_module(torch.nn.MultiheadAttention)
 class HidetMultiheadAttention(HidetModule):
     def __init__(self, torch_module: torch.nn.Module):
         super().__init__(torch_module)
-        from hidet import ops
-
         steal = dynamo_config['steal_weights']
         self.in_proj_weight_transposed = ops.transpose(self.param('in_proj_weight', steal=steal), [1, 0])
         self.out_proj_weight_transposed = ops.transpose(self.param('out_proj.weight', steal=steal), [1, 0])
 
-    def __call__(self, query: Tensor, key: Tensor, value: Tensor, key_padding_mask=None,
-                 need_weights=True, attn_mask=None, average_attn_weights=True,
-                 is_causal=False) -> Tensor:
+    def __call__(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        key_padding_mask=None,
+        need_weights=True,
+        attn_mask=None,
+        average_attn_weights=True,
+        is_causal=False,
+    ) -> Tensor:
         assert isinstance(self.mod, torch.nn.MultiheadAttention)
         supported = (
-            self.mod._qkv_same_embed_dim and
-            self.mod.bias_k is None and
-            self.mod.bias_v is None and
-            not self.mod.add_zero_attn and
-            self.mod.batch_first and
-            key_padding_mask is None and
-            not need_weights
+            self.mod._qkv_same_embed_dim
+            and self.mod.bias_k is None
+            and self.mod.bias_v is None
+            and not self.mod.add_zero_attn
+            and self.mod.batch_first
+            and key_padding_mask is None
+            and not need_weights
         )
         if not supported:
             raise NotImplementedError(
                 "Hidet Multihead Attention currently only supports "
                 "kdim=vdim=embed_dim, add_bias_kv=False, add_zero_attn=False, "
                 "batch_first=True, forward(key_padding_mask=None, need_weights=False)."
-                )
-        
+            )
+
         # Input feed forward
         wq, wk, wv = ops.split(self.in_proj_weight_transposed, parts_or_sections=3, axis=1)
         query = ops.matmul(query, wq)
@@ -453,18 +460,18 @@ class HidetMultiheadAttention(HidetModule):
             query = ops.add(query, bq)
             key = ops.add(key, bk)
             value = ops.add(value, bv)
-        
+
         # Split heads
-        split_head_dims = [query.shape[0], query.shape[1],
-                           self.mod.num_heads, query.shape[2] // self.mod.num_heads]
+        split_head_dims = [query.shape[0], query.shape[1], self.mod.num_heads, query.shape[2] // self.mod.num_heads]
         query = ops.transpose(query.reshape(split_head_dims), [0, 2, 1, 3])
         key = ops.transpose(key.reshape(split_head_dims), [0, 2, 1, 3])
         value = ops.transpose(value.reshape(split_head_dims), [0, 2, 1, 3])
 
         # fmha
-        out = regs.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask,
-                                                 dropout_p=self.mod.dropout, is_causal=is_causal)
-        
+        out = regs.scaled_dot_product_attention(
+            query, key, value, attn_mask=attn_mask, dropout_p=self.mod.dropout, is_causal=is_causal
+        )
+
         # Output feed forward
         merge_head_dims = [out.shape[0], out.shape[2], self.mod.embed_dim]
         out = ops.transpose(out, [0, 2, 1, 3]).reshape(merge_head_dims)

--- a/python/hidet/graph/frontend/torch/register_modules.py
+++ b/python/hidet/graph/frontend/torch/register_modules.py
@@ -172,7 +172,8 @@ class HidetLinear(HidetModule):
 
     def __call__(self, x: Tensor) -> Tensor:
         assert isinstance(self.mod, torch.nn.Linear)
-        return regs.linear(x=x, weight=self.transposed_weight, bias=self.param('bias', optional=True))
+        return regs.linear(x=x, weight=self.transposed_weight,
+                           bias=self.param('bias', optional=True), weight_is_transposed=True)
 
 
 @register_module(torch.nn.BatchNorm2d)

--- a/python/hidet/graph/ops/__init__.py
+++ b/python/hidet/graph/ops/__init__.py
@@ -32,7 +32,7 @@ from .arithmetic import floor, ceil, round, trunc, sqrt, rsqrt, pow, abs
 from .arithmetic import reciprocal, exp, expm1, log, log2, log10, log1p, logaddexp, erf
 from .arithmetic import bitwise_right_shift, bitwise_left_shift, bitwise_and, bitwise_invert, bitwise_or
 from .arithmetic import bitwise_xor, maximum, minimum, clamp
-from .arithmetic import isfinite, isinf, isnan, sign, where, set_strided_slice
+from .arithmetic import isfinite, isinf, isnan, sign, where, set_strided_slice, roll
 from .arithmetic import sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, asinh, acosh, atanh, atan2
 from .complex import real, imag, conj, make_complex
 from .compare import equal, not_equal, less, greater, less_equal, greater_equal

--- a/python/hidet/graph/ops/__init__.py
+++ b/python/hidet/graph/ops/__init__.py
@@ -32,7 +32,7 @@ from .arithmetic import floor, ceil, round, trunc, sqrt, rsqrt, pow, abs
 from .arithmetic import reciprocal, exp, expm1, log, log2, log10, log1p, logaddexp, erf
 from .arithmetic import bitwise_right_shift, bitwise_left_shift, bitwise_and, bitwise_invert, bitwise_or
 from .arithmetic import bitwise_xor, maximum, minimum, clamp
-from .arithmetic import isfinite, isinf, isnan, sign, where
+from .arithmetic import isfinite, isinf, isnan, sign, where, set_strided_slice
 from .arithmetic import sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, asinh, acosh, atanh, atan2
 from .complex import real, imag, conj, make_complex
 from .compare import equal, not_equal, less, greater, less_equal, greater_equal

--- a/python/hidet/graph/ops/arithmetic.py
+++ b/python/hidet/graph/ops/arithmetic.py
@@ -15,9 +15,8 @@ from typing import List, Callable, Any, Union, Optional, Dict, Sequence
 from hidet.ir import primitives
 from hidet.ir import Var, expr, dtypes
 from hidet.ir.type import DataType
-from hidet.ir.expr import Expr, Var, if_then_else, logical_or, is_constant
+from hidet.ir.expr import Expr, if_then_else, logical_or, is_constant, is_true
 from hidet.ir.tools import rewrite
-from hidet.ir.expr import Expr, if_then_else, is_true
 from hidet.utils import prod, same_list
 from .utils import Task, Operator, Tensor, TensorNode, InverseMap, compute, input_like
 from .utils import broadcast_shape, broadcast_shapes, broadcast_indices

--- a/python/hidet/graph/ops/transform.py
+++ b/python/hidet/graph/ops/transform.py
@@ -17,7 +17,7 @@ from hidet.ir.layout import RowMajorLayout
 from hidet.ir.utils import index_deserialize, index_serialize
 from hidet.utils import prod
 from .utils import Task, InverseMap, Operator, Tensor, TensorNode, compute, input_like, normalize_dim, can_broadcast
-from .utils import TensorInput
+from .utils import TensorInput, normalize_slice
 
 
 def is_true(x: Union[Expr, bool]) -> bool:
@@ -444,52 +444,11 @@ class StridedSliceOp(Operator):
         axes: Optional[Sequence[Optional[int]]] = None,
         strides: Optional[Sequence[Optional[int]]] = None,
     ):
-        starts, ends, axes, strides = self.normalize(data.shape, starts, ends, axes, strides)
+        starts, ends, axes, strides = normalize_slice(data.shape, starts, ends, axes, strides)
         task = StridedSliceTask(input_like(data, 'data'), starts, ends, axes, strides)
         super().__init__(
             inputs=[data], attributes={'starts': starts, 'ends': ends, 'axes': axes, 'strides': strides}, task=task
         )
-
-    @staticmethod
-    def normalize(data_shape, starts, ends, axes: Optional[List[int]], strides: Optional[List[Optional[int]]]):
-        # follow: https://data-apis.org/array-api/latest/API_specification/indexing.html
-        if axes is None:
-            axes = [i for i in range(len(starts))]
-        axes = normalize_dim(axes, len(data_shape))
-        if strides is None:
-            strides = [1 for _ in range(len(starts))]
-        shape = [data_shape[i] for i in axes]
-        assert len(shape) == len(starts) == len(ends) == len(axes) == len(strides)
-
-        ii, jj, kk = [], [], []
-        for i, j, k, n in zip(starts, ends, strides, shape):
-            if k is None:
-                k = 1
-            if k > 0:
-                i = i if i is not None else 0
-                j = j if j is not None else n
-                if is_constant(i, j, n) and not (-n <= i <= n and -n <= j):
-                    raise IndexError('Invalid slice')
-                j = if_then_else(j < n, j, n)
-                if is_constant(i) and i < 0:
-                    i = i + n
-                if is_constant(j) and j < 0:
-                    j = j + n
-            elif k < 0:
-                i = i if i is not None else n - 1
-                j = j if j is not None else -n - 1
-                if is_constant(i) and i < 0:
-                    i += n
-                if is_constant(j) and j < -1:
-                    j += n
-                if is_constant(i, j, n) and not (-n <= i <= n and -n - 1 <= j <= max(0, n - 1)):
-                    raise IndexError('Invalid slice')
-            else:
-                raise IndexError('slice step cannot be zero')
-            ii.append(i)
-            jj.append(j)
-            kk.append(k)
-        return ii, jj, axes, kk
 
 
 class BroadcastOp(Operator):

--- a/python/hidet/graph/ops/utils/tensor_utils.py
+++ b/python/hidet/graph/ops/utils/tensor_utils.py
@@ -160,6 +160,7 @@ def convert_to_tensor(value: Union[int, float, bool, complex, Tensor], involved_
     else:
         raise ValueError('Can not recognize dtype {}'.format(involved_tensor.dtype))
 
+
 def normalize_slice(data_shape, starts, ends, axes: Optional[List[int]], strides: Optional[List[Optional[int]]]):
     # follow: https://data-apis.org/array-api/latest/API_specification/indexing.html
     if axes is None:

--- a/python/hidet/graph/tensor.py
+++ b/python/hidet/graph/tensor.py
@@ -342,6 +342,14 @@ class Tensor:
     def __getitem__(self, item):
         from hidet.graph.ops import strided_slice
 
+        if isinstance(item, Tensor):
+            if len(item.shape) > 1:
+                raise NotImplementedError("Tensor indexing via Tensor currently only supports 1D index tensor")
+            if not item.dtype.is_integer():
+                raise TypeError("Tensor indexing via Tensor requires integer index tensor")
+            from .ops import take
+            return take(self, item, axis=0)
+
         if isinstance(item, list):
             item = tuple(item)
 

--- a/python/hidet/graph/tensor.py
+++ b/python/hidet/graph/tensor.py
@@ -348,6 +348,7 @@ class Tensor:
             if not item.dtype.is_integer():
                 raise TypeError("Tensor indexing via Tensor requires integer index tensor")
             from .ops import take
+
             return take(self, item, axis=0)
 
         if isinstance(item, list):

--- a/python/hidet/runtime/compiled_graph.py
+++ b/python/hidet/runtime/compiled_graph.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional, Tuple, Dict, Any, Callable, Union
+from typing import List, Optional, Tuple, Dict, Any, Callable
 import zipfile
 import os
 import json


### PR DESCRIPTION
1. Enhance support for `__setitem__` and` __getitem__` of Tensor; Add SetStridedSlice Op, Roll Op.
2. Add/Update torch mapping for adaptive_avg_pool3d, eq, pad, roll, matmul, new_zeros, batch_norm, MultiHeadAttention.
3. Update torch Linear mapping to optionally accept transposed weights.
4. Fix a bug where a empty graph will output a zero tensor instead of the input/weight.