### PR TITLE
[Driver] Make compilation more compatible with multi-processing #350

### DIFF
--- a/python/hidet/graph/frontend/torch/interpreter.py
+++ b/python/hidet/graph/frontend/torch/interpreter.py
@@ -359,6 +359,10 @@ class Interpreter:
                 hidet_kwargs = load_arg(node.kwargs, hidet_env)
                 try:
                     hidet_env[node.name] = exec_func(*hidet_args, **hidet_kwargs)
+                    from .register_functions import setitem
+
+                    if exec_func.functions[0] is setitem:
+                        hidet_env[str(node.args[0])] = hidet_env[node.name]
                 except Exception as e:
                     self._raise_exception(e, node.target, exec_func, hidet_args, hidet_kwargs)
             elif node.op == "call_method":
@@ -448,6 +452,10 @@ class Interpreter:
 
                 try:
                     hidet_env[node.name] = hidet_func(*hidet_args, **hidet_kwargs)
+                    from .register_functions import setitem
+
+                    if hidet_func.functions[0] is setitem:
+                        hidet_env[str(node.args[0])] = hidet_env[node.name]
                 except Exception as e:
                     self._raise_exception(e, node.target, hidet_func, hidet_args, hidet_kwargs)
 

--- a/python/hidet/graph/frontend/torch/register_functions.py
+++ b/python/hidet/graph/frontend/torch/register_functions.py
@@ -1264,3 +1264,8 @@ def torch_clone(x: Tensor, *, memory_format=torch.preserve_format):
 @register_function(torch.chunk)
 def torch_chunk(x: Tensor, chunks: int, dim: int = 0):
     return ops.split(x, parts_or_sections=chunks, axis=dim)
+
+
+@register_function(torch.einsum)
+def torch_einsum(equation, *operands):
+    return ops.einsum(equation, operands)

--- a/python/hidet/graph/frontend/torch/register_functions.py
+++ b/python/hidet/graph/frontend/torch/register_functions.py
@@ -1066,6 +1066,28 @@ def torch_mean(
     return output
 
 
+@register_function(torch.sum)
+@register_method(torch.Tensor.sum)
+def torch_sum(x: Tensor, *, dtype: Optional[DataType] = None) -> Tensor:
+    if dtype:
+        x = x.astype(dtype_from_torch(dtype))
+    output = ops.sum(x, dims=list(range(len(x.shape))), keep_dim=True)
+    return output
+
+
+@register_function(torch.sum)
+@register_method(torch.Tensor.sum)
+def torch_sum(
+    x: Tensor, dim, keepdim=False, *, dtype: Optional[DataType] = None, out: Optional[Tensor] = None
+) -> Tensor:
+    if out is not None:
+        raise NotImplementedError("hidet: does not support torch.sum(..., out=...)")
+    if dtype:
+        x = x.astype(dtype_from_torch(dtype))
+    output = ops.sum(x, dims=dim, keep_dim=keepdim)
+    return output
+
+
 @register_function(torch.cumsum)
 def torch_cumsum(x: Tensor, dim, *, dtype: Optional[DataType] = None, out: Optional[Tensor] = None) -> Tensor:
     if out is not None:

--- a/python/hidet/graph/frontend/torch/register_methods.py
+++ b/python/hidet/graph/frontend/torch/register_methods.py
@@ -297,3 +297,8 @@ def tensor_new_zeros(self: Tensor, *size, dtype=None, layout=None, device=None, 
     _ = requires_grad
 
     return ops.full(shape, dtype=dtype, device=device, value=dtype.zero)
+
+
+@register_method(torch.Tensor.zero_)
+def tensor_zero_(self: Tensor):
+    return ops.full(self.shape, dtype=self.dtype, device=self.device, value=self.dtype.zero)

--- a/python/hidet/graph/frontend/torch/register_methods.py
+++ b/python/hidet/graph/frontend/torch/register_methods.py
@@ -255,3 +255,13 @@ def tensor_repeat(self: Tensor, *sizes: int) -> Tensor:
 @register_method(torch.Tensor.detach)
 def tensor_detach(self: Tensor) -> Tensor:
     return self
+
+
+@register_method(torch.Tensor.any)
+def tensor_any(self: Tensor, dim=None, keepdim=False) -> Tensor:
+    return ops.any(self, axis=dim, keepdims=keepdim)
+
+
+@register_method(torch.Tensor.all)
+def tensor_all(self: Tensor, dim=None, keepdim=False) -> Tensor:
+    return ops.all(self, axis=dim, keepdims=keepdim)

--- a/python/hidet/graph/frontend/torch/register_methods.py
+++ b/python/hidet/graph/frontend/torch/register_methods.py
@@ -90,6 +90,11 @@ def tensor_to(self: Tensor, *args, **kwargs) -> Tensor:
             if self.is_symbolic() and instantiate_device(device_from_torch(arg)) != self.device:
                 raise NotImplementedError('hidet: Tensor.to(..., device=...) is not supported for symbolic tensors.')
             device = arg
+        elif isinstance(arg, Tensor):
+            dtype = arg.dtype
+            if self.is_symbolic() and arg.device != self.device:
+                raise NotImplementedError('hidet: Tensor.to(..., device=...) is not supported for symbolic tensors.')
+            device = arg.device
         else:
             raise ValueError(f'Unsupported argument type: {type(arg)}')
 
@@ -222,7 +227,10 @@ def tensor_type(self: Tensor, dtype: Union[str, torch.dtype], non_blocking: bool
 
 @register_method(torch.Tensor.expand)
 def tensor_expand(self: Tensor, *sizes: int) -> Tensor:
-    sizes: List[int] = list(sizes)
+    if len(sizes) == 1 and isinstance(sizes[0], (list, tuple)):
+        sizes = sizes[0]
+    else:
+        sizes: List[int] = list(sizes)
     assert len(sizes) >= len(self.shape)
     for i in range(len(sizes)):
         if sizes[i] == -1:

--- a/python/hidet/graph/frontend/torch/register_methods.py
+++ b/python/hidet/graph/frontend/torch/register_methods.py
@@ -265,3 +265,27 @@ def tensor_any(self: Tensor, dim=None, keepdim=False) -> Tensor:
 @register_method(torch.Tensor.all)
 def tensor_all(self: Tensor, dim=None, keepdim=False) -> Tensor:
     return ops.all(self, axis=dim, keepdims=keepdim)
+
+
+@register_method(torch.Tensor.matmul)
+def tensor_matmul(self: Tensor, other: Tensor) -> Tensor:
+    return ops.matmul(self, other)
+
+
+@register_method(torch.Tensor.new_zeros)
+def tensor_new_zeros(self: Tensor, *size, dtype=None, layout=None, device=None, pin_memory=False, requires_grad=False):
+    if layout is not None:
+        raise NotImplementedError("layout is not None")
+    if len(size) == 1:
+        if isinstance(size[0], (list, tuple)):
+            size = size[0]
+    shape = size
+    if dtype is None:
+        dtype = self.dtype
+    if device is None:
+        device = self.device
+
+    _ = pin_memory
+    _ = requires_grad
+
+    return ops.full(shape, dtype=dtype, device=device, value=dtype.zero)

--- a/python/hidet/graph/frontend/torch/utils.py
+++ b/python/hidet/graph/frontend/torch/utils.py
@@ -285,3 +285,12 @@ def normalize_to_scalar(value: Union[Tensor, Expr, float, int, bool]) -> Union[E
             raise RuntimeError(f'Cannot convert tensor {value.signature()} to scalar')
     else:
         return value
+
+
+def convert_to_scalar_if_possible(x: Union[Tensor, Expr, float, int, bool]) -> Optional[Union[Expr, float, int, bool]]:
+    if isinstance(x, Tensor):
+        if len(x.shape) == 0 and x.storage:
+            return x.item()
+        return None
+    else:
+        return x

--- a/python/hidet/graph/ops/__init__.py
+++ b/python/hidet/graph/ops/__init__.py
@@ -13,15 +13,8 @@
 from .matmul import batch_matmul, matmul, matmul_x86
 from .conv1d import conv1d, conv1d_gemm
 from .conv1d_transpose import conv1d_transpose
-from .conv2d import (
-    conv2d,
-    conv2d_channel_last,
-    conv2d_winograd,
-    conv2d_gemm,
-    conv2d_gemm_fp16,
-    conv2d_gemm_fp16_channel_last,
-    conv2d_gemm_image_transform,
-)
+from .conv2d import conv2d, conv2d_channel_last, conv2d_winograd, conv2d_gemm, conv2d_gemm_fp16
+from .conv2d import conv2d_gemm_fp16_channel_last, conv2d_gemm_image_transform
 from .conv2d_transpose import conv2d_transpose, conv2d_transpose_gemm
 from .conv3d import conv3d, conv3d_gemm
 from .conv3d_transpose import conv3d_transpose
@@ -38,7 +31,7 @@ from .arithmetic import add, subtract, multiply, divide, mod, remainder, negativ
 from .arithmetic import floor, ceil, round, trunc, sqrt, rsqrt, pow, abs
 from .arithmetic import reciprocal, exp, expm1, log, log2, log10, log1p, logaddexp, erf
 from .arithmetic import bitwise_right_shift, bitwise_left_shift, bitwise_and, bitwise_invert, bitwise_or
-from .arithmetic import bitwise_xor, maximum, minimum
+from .arithmetic import bitwise_xor, maximum, minimum, clamp
 from .arithmetic import isfinite, isinf, isnan, sign, where
 from .arithmetic import sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, asinh, acosh, atanh, atan2
 from .complex import real, imag, conj, make_complex

--- a/python/hidet/graph/ops/__init__.py
+++ b/python/hidet/graph/ops/__init__.py
@@ -32,7 +32,7 @@ from .arithmetic import floor, ceil, round, trunc, sqrt, rsqrt, pow, abs
 from .arithmetic import reciprocal, exp, expm1, log, log2, log10, log1p, logaddexp, erf
 from .arithmetic import bitwise_right_shift, bitwise_left_shift, bitwise_and, bitwise_invert, bitwise_or
 from .arithmetic import bitwise_xor, maximum, minimum, clamp
-from .arithmetic import isfinite, isinf, isnan, sign, where
+from .arithmetic import isfinite, isinf, isnan, sign, where, set_strided_slice, roll
 from .arithmetic import sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, asinh, acosh, atanh, atan2
 from .complex import real, imag, conj, make_complex
 from .compare import equal, not_equal, less, greater, less_equal, greater_equal

--- a/python/hidet/graph/ops/__init__.py
+++ b/python/hidet/graph/ops/__init__.py
@@ -47,5 +47,6 @@ from .fusion import fused_operator
 from .transfer import transfer
 from .special import barrier
 from .distributed import all_reduce, all_gather, reduce_scatter
+from .linear import einsum
 
 from . import utils

--- a/python/hidet/graph/ops/__init__.py
+++ b/python/hidet/graph/ops/__init__.py
@@ -24,7 +24,7 @@ from .activation import relu, leaky_relu, sigmoid, hardsigmoid, clip, relu6, pre
 from .activation import logsigmoid, celu, hardshrink, softplus, softsign, tanhshrink
 from .activation import softshrink, softmax, softmin, hardtanh
 from .attention import attention
-from .normalize import batch_norm_infer, instance_norm, layer_norm, group_norm
+from .normalize import batch_norm_infer, instance_norm, layer_norm, group_norm, lp_norm
 from .image import resize2d
 from .create import full, arange, linspace, tri
 from .arithmetic import add, subtract, multiply, divide, mod, remainder, negative, positive, square

--- a/python/hidet/graph/ops/arithmetic.py
+++ b/python/hidet/graph/ops/arithmetic.py
@@ -718,7 +718,7 @@ class SetStridedSliceOp(Operator):
 
 
 class RollOp(Operator):
-    def __init__(self, x: Tensor, shifts: Sequence[int], dims: Sequence[int]) -> Tensor:
+    def __init__(self, x: Tensor, shifts: Sequence[int], dims: Sequence[int]):
         if not len(shifts) == len(dims):
             raise ValueError('Roll must have same size shifts and dims, got {} and {}'.format(len(shifts), len(dims)))
         task = RollTask(input_like(x, 'x'), shifts, dims)

--- a/python/hidet/graph/ops/attention/attention.py
+++ b/python/hidet/graph/ops/attention/attention.py
@@ -397,7 +397,7 @@ class AttnTask(Task):
             def copy_k_g2s_sm80(
                 k: f16[k_head + [d_size, n_kv_size]], smem_k: smem_k_type, offset_j: i32, offset_k: i32
             ):
-                o_head_index = spatial(*o_head).map(blockIdx.y)
+                o_head_index = spatial(*o_head).map(blockIdx.x // i_split)
                 gmem_k = k[broadcast_indices(o_head_index, k_head, o_head)][offset_k:, offset_j:]
                 for i, j_seg in k_g2s_layout.on(threadIdx.x):
                     j = j_seg * 8
@@ -411,7 +411,7 @@ class AttnTask(Task):
 
             @hidet.script
             def copy_v_g2s_sm80(v: f16[v_head + [n_kv_size, d_size]], smem_v: smem_v_type, offset_j: i32):
-                o_head_index = spatial(*o_head).map(blockIdx.y)
+                o_head_index = spatial(*o_head).map(blockIdx.x // i_split)
                 gmem_v = v[broadcast_indices(o_head_index, v_head, o_head)][offset_j:, :]
                 for i, j_seg in v_g2s_layout.on(threadIdx.x):
                     j = j_seg * 8
@@ -421,7 +421,7 @@ class AttnTask(Task):
 
             @hidet.script
             def copy_q_g2s_sm80(q: f16[q_head + [n_size, d_size]], smem_q: smem_q_type, offset_i: i32):
-                o_head_index = spatial(*o_head).map(blockIdx.y)
+                o_head_index = spatial(*o_head).map(blockIdx.x // i_split)
                 gmem_q = q[broadcast_indices(o_head_index, q_head, o_head)][offset_i:, :]
                 for i, j_seg in q_g2s_layout.on(threadIdx.x):
                     j = j_seg * 8
@@ -433,7 +433,7 @@ class AttnTask(Task):
             def copy_k_g2s_sm75(
                 k: f16[k_head + [d_size, n_kv_size]], smem_k: smem_k_type, offset_j: i32, offset_k: i32
             ):
-                o_head_index = spatial(*o_head).map(blockIdx.y)
+                o_head_index = spatial(*o_head).map(blockIdx.x // i_split)
                 gmem_k = k[broadcast_indices(o_head_index, k_head, o_head)][offset_k:, offset_j:]
                 for i, j in k_g2s_layout_sm75.on(threadIdx.x):
                     if threadIdx.x < k_g2s_layout_sm75.num_workers and i < smem_k_type.shape[0]:
@@ -444,7 +444,7 @@ class AttnTask(Task):
 
             @hidet.script
             def copy_v_g2s_sm75(v: f16[v_head + [n_kv_size, d_size]], smem_v: smem_v_type, offset_j: i32):
-                o_head_index = spatial(*o_head).map(blockIdx.y)
+                o_head_index = spatial(*o_head).map(blockIdx.x // i_split)
                 gmem_v = v[broadcast_indices(o_head_index, v_head, o_head)][offset_j:, :]
                 for i, j in v_g2s_layout_sm75.on(threadIdx.x):
                     if threadIdx.x < v_g2s_layout_sm75.num_workers and i < smem_v_type.shape[0]:
@@ -455,7 +455,7 @@ class AttnTask(Task):
 
             @hidet.script
             def copy_q_g2s_sm75(q: f16[q_head + [n_size, d_size]], smem_q: smem_q_type, offset_i: i32):
-                o_head_index = spatial(*o_head).map(blockIdx.y)
+                o_head_index = spatial(*o_head).map(blockIdx.x // i_split)
                 gmem_q = q[broadcast_indices(o_head_index, q_head, o_head)][offset_i:, :]
                 for i, j in q_g2s_layout_sm75.on(threadIdx.x):
                     if threadIdx.x < q_g2s_layout_sm75.num_workers and i < smem_q_type.shape[0]:
@@ -488,7 +488,7 @@ class AttnTask(Task):
             @hidet.script
             def copy_o_r2g(o: f16[o_head + [n_size, d_size]], regs_o: regs_o_type, offset_i: i32):
                 warp_id, lane_id = threadIdx.x / 32, threadIdx.x % 32
-                o_head_index = spatial(*o_head).map(blockIdx.y)
+                o_head_index = spatial(*o_head).map(blockIdx.x // i_split)
                 gmem_o = o[o_head_index][offset_i:, :]
                 for k_round in range(warp_count_k):
                     for wi, wj, wk in spatial(warp_count_m_o, warp_count_n_o, warp_count_k_o).on(warp_id):
@@ -652,12 +652,12 @@ class AttnTask(Task):
                 v: f16[v_head + [n_kv_size, d_size]],
                 o: f16[o_head + [n_size, d_size]],
             ):
-                attrs.cuda.grid_dim = (i_split, bs)
+                attrs.cuda.grid_dim = i_split * bs
                 attrs.cuda.block_dim = block_size
                 attrs.cuda.min_blocks = 1
                 attrs.cuda.dynamic_smem_bytes = dynamic_smem_bytes
 
-                offset_i = blockIdx.x * i_rows_per_tb
+                offset_i = (blockIdx.x % i_split) * i_rows_per_tb
 
                 smem_q = tensor_pointer('float16', shape=smem_q_type.shape, layout=smem_q_type.layout)
                 smem_k = tensor_pointer('float16', shape=smem_k_db_type.shape, layout=smem_k_db_type.layout)
@@ -702,7 +702,7 @@ class AttnTask(Task):
 
                 j_tiles = cdiv(n_kv_size, block_j)
                 if is_causal:
-                    j_tiles = min(cdiv((blockIdx.x + 1) * block_i, block_j), j_tiles)
+                    j_tiles = min(cdiv(((blockIdx.x % i_split) + 1) * block_i, block_j), j_tiles)
                 for j in range(j_tiles):
                     offset_j = block_j * j
 

--- a/python/hidet/graph/ops/linear.py
+++ b/python/hidet/graph/ops/linear.py
@@ -1,0 +1,59 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Sequence
+from .utils import Tensor
+from .matmul import matmul
+
+# ToDo: Actually fully implement einsum, supporting same usage as Numpy and Torch
+
+# Do ad-hoc pattern matching: only support simple cases such as matrix multiply
+def einsum(equation: str, operands: Sequence[Tensor]):
+    if '...' in equation:
+        raise NotImplementedError('einsum currently does not support ellipsis')
+    if len(operands) != 2:
+        raise NotImplementedError('einsum currently only supports 2 operands')
+
+    a = operands[0]
+    b = operands[1]
+    equation = equation.replace(' ', '')
+    lhs, rhs = equation.split('->')
+    a_subs, b_subs = lhs.split(',')
+
+    if len(rhs) != len(a_subs) or len(a_subs) != len(b_subs):
+        raise NotImplementedError('einsum currently only supports inputs and output of same rank')
+
+    a_batch, a_dims = a_subs[:-2], a_subs[-2:]
+    b_batch, b_dims = b_subs[:-2], b_subs[-2:]
+    c_batch, c_dims = rhs[:-2], rhs[-2:]
+
+    if a_batch != b_batch or a_batch != c_batch:
+        raise NotImplementedError('einsum currently only supports batched matmul')
+
+    if a_dims[1] == b_dims[0]:
+        c = matmul(a, b)
+    elif a_dims[1] == b_dims[1]:
+        c = matmul(a, b.transpose(-1, -2))
+    elif a_dims[0] == b_dims[0]:
+        c = matmul(a.transpose(-1, -2), b)
+    elif a_dims[0] == b_dims[1]:
+        c = matmul(a.transpose(-1, -2), b.transpose(-1, -2))
+    else:
+        raise NotImplementedError('einsum currently only supports batched matmul')
+
+    transpose_c = (c_dims[0] == b_dims[0] or c_dims[0] == b_dims[1]) and (
+        c_dims[1] == a_dims[0] or c_dims[1] == a_dims[1]
+    )
+
+    if transpose_c:
+        return c.transpose(-1, -2)
+    else:
+        return c

--- a/python/hidet/graph/ops/normalize/__init__.py
+++ b/python/hidet/graph/ops/normalize/__init__.py
@@ -10,4 +10,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from .layers import batch_norm_infer, layer_norm, instance_norm, group_norm
+from .lp import lp_norm
 from . import resolve

--- a/python/hidet/graph/ops/normalize/lp.py
+++ b/python/hidet/graph/ops/normalize/lp.py
@@ -1,0 +1,98 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from hidet.ir import primitives as prim
+from hidet.ir.compute import reduce
+from hidet.ir.expr import cast
+from hidet.graph.ops.utils import Task, Operator, Tensor, TensorNode
+from hidet.graph.ops.utils import compute, input_like, normalize_dim
+
+
+class LpNormTask(Task):
+    """
+    Performs LP normalization along specified dimension.
+    For a tensor input of shape [n0, n1, ..., ndim, ..., nk], each
+    ndim-element vector v along dimension dim is transformed as:
+    v = v / max(sum(pow(abs(v), p)), eps)
+    """
+
+    def __init__(self, x: TensorNode, p: float, dim: int, eps: float):
+        x_shape = x.const_shape
+        y_shape = x_shape
+        dtype = x.type.dtype
+        reduce_shape = []
+        other_shape = []
+        for idx, size in enumerate(x_shape):
+            if idx == dim:
+                reduce_shape.append(size)
+            else:
+                other_shape.append(size)
+
+        def sum_compute(*indices):
+            def sum_reduce(*reduction_axis):
+                x_indices = []
+                p = 0
+                q = 0
+                for i in range(len(x.shape)):
+                    if i != dim:
+                        x_indices.append(indices[p])
+                        p += 1
+                    else:
+                        x_indices.append(reduction_axis[q])
+                        q += 1
+                assert p == len(indices) and q == len(reduction_axis)
+                # Force fp32 reduction for accuracy
+                return prim.pow(cast(prim.abs(x[x_indices]), 'float32'), p)
+
+            return reduce(shape=reduce_shape, fcompute=sum_reduce, reduce_type='sum')
+
+        sum_ = compute(name='sum', shape=other_shape, fcompute=sum_compute)
+
+        p_norm = compute(name='p_norm', shape=other_shape, fcompute=lambda *indices: prim.pow(sum_[indices], 1.0 / p))
+
+        def y_compute(*indices):
+            norm_indices = [index for i, index in enumerate(indices) if i != dim]
+            return cast(x[indices] / prim.max(p_norm[norm_indices], eps), dtype)
+
+        y = compute(name='y', shape=y_shape, fcompute=y_compute)
+
+        super().__init__(name='lp_norm', inputs=[x], outputs=[y], attributes={'p': p, 'dim': dim, 'eps': eps})
+
+
+class LpNormOp(Operator):
+    def __init__(self, x: Tensor, p: float, dim: int, eps: float):
+        super().__init__(
+            inputs=[x], attributes={'p': p, 'dim': dim, 'eps': eps}, task=LpNormTask(input_like(x, 'x'), p, dim, eps)
+        )
+
+
+def lp_norm(x: Tensor, p=2.0, dim=1, eps=1e-12):
+    """LP norm.
+
+    Parameters
+    ----------
+    x: Tensor
+        The data to be normalized.
+    p: float
+        The exponent value in the norm formulation.
+    dim: int
+        The dimension to reduce.
+    eps: float
+        Small value to avoid division by zero.
+
+    Returns
+    -------
+    ret: Tensor
+        The normalized tensor.
+    """
+    # Normalize dim
+    dim = normalize_dim(dim, rank=len(x.shape))
+    return LpNormOp(x, p, dim, eps).outputs[0]

--- a/python/hidet/graph/ops/reduce/reduce.py
+++ b/python/hidet/graph/ops/reduce/reduce.py
@@ -56,7 +56,7 @@ class ReduceTask(Task):
     def allow_prologue(self) -> bool:
         return False
 
-    def implement_cuda(self, working_dir: str) -> IRModule:
+    def implement_cuda(self, working_dir: str) -> Union[IRModule, List[IRModule]]:
         rank = len(self.inputs[0].shape)
         if rank - 1 in self.dims:
             return tune.extract_ir_modules(self.cuda_schedule_reduce_by_warp)
@@ -80,7 +80,7 @@ class ReduceTask(Task):
         xdtype = x.type.dtype
         shape: List[Int] = list(x.shape)
         lanes = 1
-        vtype: DataType = xdtype
+        vtype: Union[DataType, VectorType] = xdtype
         if xdtype.nbytes < 4:
             num_eles: int = 4 // xdtype.nbytes
             if is_constant(shape[-1]) and shape[-1] % num_eles == 0:
@@ -204,7 +204,7 @@ class ReduceTask(Task):
         shape: List[Int] = list(x.shape)
 
         lanes = 1
-        vtype: DataType = xdtype
+        vtype: Union[VectorType, DataType] = xdtype
         if xdtype.nbytes < 4:
             num_eles: int = 4 // xdtype.nbytes
             if shape[-1] % num_eles == 0:

--- a/python/hidet/graph/ops/transform.py
+++ b/python/hidet/graph/ops/transform.py
@@ -17,7 +17,7 @@ from hidet.ir.layout import RowMajorLayout
 from hidet.ir.utils import index_deserialize, index_serialize
 from hidet.utils import prod
 from .utils import Task, InverseMap, Operator, Tensor, TensorNode, compute, input_like, normalize_dim, can_broadcast
-from .utils import TensorInput
+from .utils import TensorInput, normalize_slice
 
 
 def is_true(x: Union[Expr, bool]) -> bool:
@@ -444,52 +444,11 @@ class StridedSliceOp(Operator):
         axes: Optional[Sequence[Optional[int]]] = None,
         strides: Optional[Sequence[Optional[int]]] = None,
     ):
-        starts, ends, axes, strides = self.normalize(data.shape, starts, ends, axes, strides)
+        starts, ends, axes, strides = normalize_slice(data.shape, starts, ends, axes, strides)
         task = StridedSliceTask(input_like(data, 'data'), starts, ends, axes, strides)
         super().__init__(
             inputs=[data], attributes={'starts': starts, 'ends': ends, 'axes': axes, 'strides': strides}, task=task
         )
-
-    @staticmethod
-    def normalize(data_shape, starts, ends, axes: Optional[List[int]], strides: Optional[List[Optional[int]]]):
-        # follow: https://data-apis.org/array-api/latest/API_specification/indexing.html
-        if axes is None:
-            axes = [i for i in range(len(starts))]
-        axes = normalize_dim(axes, len(data_shape))
-        if strides is None:
-            strides = [1 for _ in range(len(starts))]
-        shape = [data_shape[i] for i in axes]
-        assert len(shape) == len(starts) == len(ends) == len(axes) == len(strides)
-
-        ii, jj, kk = [], [], []
-        for i, j, k, n in zip(starts, ends, strides, shape):
-            if k is None:
-                k = 1
-            if k > 0:
-                i = i if i is not None else 0
-                j = j if j is not None else n
-                if is_constant(i, j, n) and not (-n <= i <= n and -n <= j):
-                    raise IndexError('Invalid slice')
-                j = if_then_else(j < n, j, n)
-                if is_constant(i) and i < 0:
-                    i = i + n
-                if is_constant(j) and j < 0:
-                    j = j + n
-            elif k < 0:
-                i = i if i is not None else n - 1
-                j = j if j is not None else -n - 1
-                if is_constant(i) and i < 0:
-                    i += n
-                if is_constant(j) and j < -1:
-                    j += n
-                if is_constant(i, j, n) and not (-n <= i <= n and -n - 1 <= j <= max(0, n - 1)):
-                    raise IndexError('Invalid slice')
-            else:
-                raise IndexError('slice step cannot be zero')
-            ii.append(i)
-            jj.append(j)
-            kk.append(k)
-        return ii, jj, axes, kk
 
 
 class BroadcastOp(Operator):

--- a/python/hidet/graph/ops/utils/tensor_utils.py
+++ b/python/hidet/graph/ops/utils/tensor_utils.py
@@ -14,7 +14,7 @@ from typing import Tuple, List, Union, Sequence, Optional
 import builtins
 from hidet.ir.layout import DataLayout
 from hidet.ir.type import Int
-from hidet.ir.expr import Var, Expr, Constant, is_constant
+from hidet.ir.expr import Var, Expr, Constant, is_constant, if_then_else
 from hidet.ir.type import TensorType, tensor_type, DataType
 from hidet.ir.task import Task, InverseMap
 from hidet.ir.module import IRModule
@@ -159,3 +159,44 @@ def convert_to_tensor(value: Union[int, float, bool, complex, Tensor], involved_
             return full_like(involved_tensor, fill_value=value, shape=[], dtype='float32')
     else:
         raise ValueError('Can not recognize dtype {}'.format(involved_tensor.dtype))
+
+
+def normalize_slice(data_shape, starts, ends, axes: Optional[List[int]], strides: Optional[List[Optional[int]]]):
+    # follow: https://data-apis.org/array-api/latest/API_specification/indexing.html
+    if axes is None:
+        axes = [i for i in range(len(starts))]
+    axes = normalize_dim(axes, len(data_shape))
+    if strides is None:
+        strides = [1 for _ in range(len(starts))]
+    shape = [data_shape[i] for i in axes]
+    assert len(shape) == len(starts) == len(ends) == len(axes) == len(strides)
+
+    ii, jj, kk = [], [], []
+    for i, j, k, n in zip(starts, ends, strides, shape):
+        if k is None:
+            k = 1
+        if k > 0:
+            i = i if i is not None else 0
+            j = j if j is not None else n
+            if is_constant(i, j, n) and not (-n <= i <= n and -n <= j):
+                raise IndexError('Invalid slice')
+            j = if_then_else(j < n, j, n)
+            if is_constant(i) and i < 0:
+                i = i + n
+            if is_constant(j) and j < 0:
+                j = j + n
+        elif k < 0:
+            i = i if i is not None else n - 1
+            j = j if j is not None else -n - 1
+            if is_constant(i) and i < 0:
+                i += n
+            if is_constant(j) and j < -1:
+                j += n
+            if is_constant(i, j, n) and not (-n <= i <= n and -n - 1 <= j <= max(0, n - 1)):
+                raise IndexError('Invalid slice')
+        else:
+            raise IndexError('slice step cannot be zero')
+        ii.append(i)
+        jj.append(j)
+        kk.append(k)
+    return ii, jj, axes, kk

--- a/python/hidet/graph/tensor.py
+++ b/python/hidet/graph/tensor.py
@@ -342,6 +342,15 @@ class Tensor:
     def __getitem__(self, item):
         from hidet.graph.ops import strided_slice
 
+        if isinstance(item, Tensor):
+            if len(item.shape) > 1:
+                raise NotImplementedError("Tensor indexing via Tensor currently only supports 1D index tensor")
+            if not item.dtype.is_integer():
+                raise TypeError("Tensor indexing via Tensor requires integer index tensor")
+            from .ops import take
+
+            return take(self, item, axis=0)
+
         if isinstance(item, list):
             item = tuple(item)
 

--- a/python/hidet/graph/transforms/graph_patterns/conv2d_patterns.py
+++ b/python/hidet/graph/transforms/graph_patterns/conv2d_patterns.py
@@ -125,7 +125,7 @@ class ThreeConv2dFusionPattern(SubgraphRewriteRule):
                     x,
                     w,
                     stride=op1.attrs['stride'],
-                    dilations=op1.attrs['dilation'],
+                    dilations=op1.attrs['dilations'],
                     groups=1,
                     padding=op1.attrs['padding'],
                 )

--- a/python/hidet/ir/primitives/__init__.py
+++ b/python/hidet/ir/primitives/__init__.py
@@ -15,7 +15,7 @@ from .func import register_primitive_function, is_primitive_function, lookup_pri
 # pylint: disable=redefined-builtin
 from .math import sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, asinh, acosh, atanh, expm1, abs
 from .math import max, min, exp, pow, sqrt, rsqrt, erf, ceil, log, log2, log10, log1p, round, floor, trunc
-from .math import isfinite, isinf, isnan, make_vector
+from .math import isfinite, isinf, isnan, make_vector, atan2, mod
 
 from .complex import real, imag, conj, make_complex
 

--- a/python/hidet/ir/primitives/cuda/math/float16.py
+++ b/python/hidet/ir/primitives/cuda/math/float16.py
@@ -62,6 +62,7 @@ class CUDAFloat16MathFunctionSet(MathFunctionSet):
     # pylint: disable=abstract-method
     def register(self):
         entries = {
+            'abs': ['__habs', 1],
             'sin': ['hsin', 1],
             'cos': ['hcos', 1],
             'exp': ['hexp', 1],
@@ -141,6 +142,9 @@ class CUDAFloat16MathFunctionSet(MathFunctionSet):
     def call(self, name: str, *args) -> Expr:
         entry = primitive_func_pool.lookup_by_name(name)
         return entry.var(*args)
+
+    def abs(self, a: Expr) -> Expr:
+        return self.call('cuda_f16_abs', a)
 
     def sin(self, a: Expr) -> Expr:
         return self.call('cuda_f16_sin', a)

--- a/python/hidet/runtime/compiled_graph.py
+++ b/python/hidet/runtime/compiled_graph.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional, Tuple, Dict, Any, Callable, Union
+from typing import List, Optional, Tuple, Dict, Any, Callable
 import zipfile
 import os
 import json
@@ -95,7 +95,6 @@ class CompiledGraph:
         # derived properties (will be initialized in _init_compiled_graph at the end of this constructor)
         self.dynamic_dims: List[Tuple[str, Tuple[int, int]]] = []  # [(name, (tensor_index, dim_index))]
         self.is_dynamic: bool = False
-        self.constant_outputs: List[Union[None, Tensor]] = []
 
         # runtime state
         self.working_dir: str = hidet.utils.cache_file('graphs', self.meta.graph_hash)
@@ -145,11 +144,6 @@ class CompiledGraph:
             self.is_dynamic = True
         else:
             self.is_dynamic = False
-        for out_idx in self.graph_execution.outputs_index:
-            if out_idx in self.graph_execution.weights_index:
-                self.constant_outputs.append(self.weights[self.graph_execution.weights_index.index(out_idx)])
-            else:
-                self.constant_outputs.append(None)
 
         # initialize weights
         weights_buffer = Array(void_p, len(self.weights))
@@ -209,13 +203,15 @@ class CompiledGraph:
             runtime_api.set_symbol_value(name, symbol_dims[-1])
         return tuple(symbol_dims)
 
-    def _create_outputs(self):
+    def _create_outputs(self, inputs):
         from hidet.graph.tensor import empty
 
         outputs = []
-        for output_index, (sig, const_out) in enumerate(zip(self.meta.outputs, self.constant_outputs)):
-            if const_out is not None:
-                outputs.append(const_out)
+        for output_index, (exec_idx, sig) in enumerate(zip(self.graph_execution.outputs_index, self.meta.outputs)):
+            if exec_idx in self.graph_execution.inputs_index:
+                outputs.append(inputs[self.graph_execution.inputs_index.index(exec_idx)])
+            elif exec_idx in self.graph_execution.weights_index:
+                outputs.append(self.weights[self.graph_execution.weights_index.index(exec_idx)])
             else:
                 if self.is_dynamic:
                     shape_buffer = Array(i32, len(sig.shape))
@@ -240,7 +236,7 @@ class CompiledGraph:
 
     def _run_fast_path(self, inputs, symbol_dims: Tuple[int, ...]):
         # create output tensors
-        outputs = self._create_outputs()
+        outputs = self._create_outputs(inputs)
 
         # prepare workspace
         self._prepare_workspace()

--- a/python/hidet/utils/multiprocess.py
+++ b/python/hidet/utils/multiprocess.py
@@ -48,7 +48,8 @@ def parallel_imap(func: Callable, jobs: Sequence[Any], num_workers: Optional[int
     if num_workers is None:
         num_workers = os.cpu_count()
 
-    with multiprocessing.Pool(num_workers) as pool:
+    ctx = multiprocessing.get_context('fork')
+    with ctx.Pool(num_workers) as pool:
         yield from pool.imap(_wrapped_func, range(len(jobs)))
 
     _job_queue = None
@@ -65,7 +66,8 @@ def parallel_map(func: Callable, jobs: Sequence[Any], num_workers: Optional[int]
     if num_workers is None:
         num_workers = os.cpu_count()
 
-    with multiprocessing.Pool(num_workers) as pool:
+    ctx = multiprocessing.get_context('fork')
+    with ctx.Pool(num_workers) as pool:
         ret = pool.map(_wrapped_func, range(len(jobs)))
 
     _job_queue = None


### PR DESCRIPTION
This change adds a filelock to task compilation so that workflows such as distributed inference only builds the task once and avoids any potential data (file) races. 

Currently, only task building is included in the filelock because in general, compiled graphs will be different and compiled modules is already protected by task building. 