### PR TITLE
[Quantization] fix quantization pass bug

### DIFF
--- a/python/hidet/graph/transforms/__init__.py
+++ b/python/hidet/graph/transforms/__init__.py
@@ -49,16 +49,16 @@ def optimize(graph: FlowGraph) -> FlowGraph:
     ret: FlowGraph
         The optimized flow graph.
     """
+    ctx = PassContext.current()
     passes = [
         subgraph_rewrite_pass(),
         automatic_mix_precision_pass(),
-        subgraph_rewrite_pass(),
+        subgraph_rewrite_pass(ctx.configs['quantize_patterns']),
         selective_quantize_pass(),
         resolve_variant_pass(),
         fuse_operator_pass(),
         eliminate_barrier_pass(),
     ]
-    ctx = PassContext.current()
     for inst in ctx.instruments:
         inst.before_all_passes(graph)
     for optimize_pass in passes:

--- a/python/hidet/graph/transforms/__init__.py
+++ b/python/hidet/graph/transforms/__init__.py
@@ -53,7 +53,6 @@ def optimize(graph: FlowGraph) -> FlowGraph:
     passes = [
         subgraph_rewrite_pass(),
         automatic_mix_precision_pass(),
-        subgraph_rewrite_pass(ctx.configs['quantize_patterns']),
         selective_quantize_pass(),
         resolve_variant_pass(),
         fuse_operator_pass(),

--- a/python/hidet/graph/transforms/base.py
+++ b/python/hidet/graph/transforms/base.py
@@ -164,7 +164,6 @@ class PassContext:
             for pat in patterns:
                 if isinstance(pat, SubgraphRewriteRule):
                     self.configs['quantize_patterns'].append(pat)
-                    return None
                 elif issubclass(pat, SubgraphRewriteRule):
                     self.configs['quantize_patterns'].append(pat())
         else:

--- a/python/hidet/graph/transforms/subgraph_rewrite.py
+++ b/python/hidet/graph/transforms/subgraph_rewrite.py
@@ -141,5 +141,5 @@ class SubgraphRewritePass(GraphPass):
         return False, graph
 
 
-def subgraph_rewrite_pass() -> GraphPass:
-    return SubgraphRewritePass()
+def subgraph_rewrite_pass(rewrite_rules: Optional[List[SubgraphRewriteRule]] = None) -> GraphPass:
+    return SubgraphRewritePass(rewrite_rules)


### PR DESCRIPTION
For llama 7b, decoding with no prefill

fp16 - 128 tokens
org_t: 3.048099994659424s
avg_t: 0.0044784750789403915s

int8 - 128 tokens
org_t: 2.2229115962982178s
avg_t: 0.0038476772606372833s