### PR TITLE
[Operator] Enhancements to Reduce

### DIFF
--- a/.github/scripts/run_tests.py
+++ b/.github/scripts/run_tests.py
@@ -57,7 +57,8 @@ if __name__ == '__main__':
         cmd = get_bench_cmd(run_type, run_id, run_name, run_param_name, run_dtype_name)
         outputs = run_command(cmd)
         if outputs:
-            latency = float(outputs[-2].split('\n')[0]) # Get last line
+            # The second last line of All benchmark scripts' stdout is the latency. (Last line is empty)
+            latency = float(outputs.split('\n')[-2])
             run_config['latency'] = latency
         else:
             run_config['latency'] = 999.99

--- a/.github/scripts/run_tests.py
+++ b/.github/scripts/run_tests.py
@@ -19,6 +19,8 @@ def run_command(cmd):
         for line in stderr:
             print(line, end='')
         raise RuntimeError(f'Command {cmd} failed with return code {ret}.')
+    print('STDOUT:')
+    print(stdout)
     return stdout
 
 def get_bench_cmd(run_type, run_id, run_name, run_param_name, dtype):

--- a/.github/scripts/run_tests.py
+++ b/.github/scripts/run_tests.py
@@ -19,8 +19,6 @@ def run_command(cmd):
         for line in stderr:
             print(line, end='')
         raise RuntimeError(f'Command {cmd} failed with return code {ret}.')
-    print('STDOUT:')
-    print(stdout)
     return stdout
 
 def get_bench_cmd(run_type, run_id, run_name, run_param_name, dtype):
@@ -59,7 +57,7 @@ if __name__ == '__main__':
         cmd = get_bench_cmd(run_type, run_id, run_name, run_param_name, run_dtype_name)
         outputs = run_command(cmd)
         if outputs:
-            latency = float(outputs[-1].split('\n')[0]) # Get last line
+            latency = float(outputs[-2].split('\n')[0]) # Get last line
             run_config['latency'] = latency
         else:
             run_config['latency'] = 999.99

--- a/python/hidet/graph/ops/pool.py
+++ b/python/hidet/graph/ops/pool.py
@@ -470,12 +470,12 @@ class AdaptivePoolChannelLastResolveRule(ResolveRule):
 
             # Since sometimes the h and w dimensions are large, separating them into two kernels may be faster
             if reduce_type == 'max':
-                return [max(x, dims=[1, 2], keep_dim=True)]
+                # return [max(x, dims=[1, 2], keep_dim=True)]
                 reduce_h = max(x, dims=1, keep_dim=True)
                 reduce_hw = max(reduce_h, dims=2, keep_dim=True)
                 return [reduce_hw]
             elif reduce_type == 'avg':
-                return [mean(x, dims=[1, 2], keep_dim=True)]
+                # return [mean(x, dims=[1, 2], keep_dim=True)]
                 reduce_h = mean(x, dims=1, keep_dim=True)
                 reduce_hw = mean(reduce_h, dims=2, keep_dim=True)
                 return [reduce_hw]

--- a/python/hidet/graph/ops/pool.py
+++ b/python/hidet/graph/ops/pool.py
@@ -452,3 +452,28 @@ class AdaptivePoolResolveRule(ResolveRule):
             elif reduce_type == 'avg':
                 return [mean(x, dims=dims[2:], keep_dim=True)]
         return None
+
+@register_resolve_rule(AdaptivePoolChannelLastOp)
+class AdaptivePoolResolveRule(ResolveRule):
+    def resolve(self, op: Operator) -> Optional[List[Tensor]]:
+        assert isinstance(op, AdaptivePoolChannelLastOp)
+        x: Tensor = op.inputs[0]
+        output_size = op.attrs['output_size']
+        reduce_type = op.reduce_type
+        resolve_to_reduce = output_size == 1 if isinstance(output_size, int) else all(d == 1 for d in output_size)
+        if resolve_to_reduce:
+            dims = [i for i in range(len(x.shape))]
+            from hidet.graph.ops import mean, max
+
+            # Since sometimes the h and w dimensions are large, separating them into two kernels may be faster
+            if reduce_type == 'max':
+                reduce_h = max(x, dims=1, keep_dim=True)
+                reduce_hw = max(reduce_h, dims=2, keep_dim=True)
+                return [reduce_hw]
+                # return [max(x, dims=dims[1:-1], keep_dim=True)]
+            elif reduce_type == 'avg':
+                reduce_h = mean(x, dims=1, keep_dim=True)
+                reduce_hw = mean(reduce_h, dims=2, keep_dim=True)
+                return [reduce_hw]
+                # return [mean(x, dims=dims[1:-1], keep_dim=True)]
+        return None

--- a/python/hidet/graph/ops/pool.py
+++ b/python/hidet/graph/ops/pool.py
@@ -468,15 +468,8 @@ class AdaptivePoolChannelLastResolveRule(ResolveRule):
         if resolve_to_reduce:
             from hidet.graph.ops import mean, max
 
-            # Since sometimes the h and w dimensions are large, separating them into two kernels may be faster
             if reduce_type == 'max':
-                # return [max(x, dims=[1, 2], keep_dim=True)]
-                reduce_h = max(x, dims=1, keep_dim=True)
-                reduce_hw = max(reduce_h, dims=2, keep_dim=True)
-                return [reduce_hw]
+                return [max(x, dims=[1, 2], keep_dim=True)]
             elif reduce_type == 'avg':
-                # return [mean(x, dims=[1, 2], keep_dim=True)]
-                reduce_h = mean(x, dims=1, keep_dim=True)
-                reduce_hw = mean(reduce_h, dims=2, keep_dim=True)
-                return [reduce_hw]
+                return [mean(x, dims=[1, 2], keep_dim=True)]
         return None

--- a/python/hidet/graph/ops/pool.py
+++ b/python/hidet/graph/ops/pool.py
@@ -470,10 +470,12 @@ class AdaptivePoolChannelLastResolveRule(ResolveRule):
 
             # Since sometimes the h and w dimensions are large, separating them into two kernels may be faster
             if reduce_type == 'max':
+                return [max(x, dims=[1, 2], keep_dim=True)]
                 reduce_h = max(x, dims=1, keep_dim=True)
                 reduce_hw = max(reduce_h, dims=2, keep_dim=True)
                 return [reduce_hw]
             elif reduce_type == 'avg':
+                return [mean(x, dims=[1, 2], keep_dim=True)]
                 reduce_h = mean(x, dims=1, keep_dim=True)
                 reduce_hw = mean(reduce_h, dims=2, keep_dim=True)
                 return [reduce_hw]

--- a/python/hidet/graph/ops/reduce/reduce.py
+++ b/python/hidet/graph/ops/reduce/reduce.py
@@ -283,7 +283,6 @@ class ReduceTask(Task):
 
             @hidet.script
             def reduce_kernel(x: xdtype[x.shape], y: xdtype[y.shape]):
-                # Each 256-thread ThreadBlock handles 512 columns
                 attrs.cuda.grid_dim = grid_size
                 attrs.cuda.block_dim = block_size
                 attrs.cuda.min_blocks = 1

--- a/python/hidet/graph/ops/reduce/reduce.py
+++ b/python/hidet/graph/ops/reduce/reduce.py
@@ -62,7 +62,7 @@ class ReduceTask(Task):
         if rank - 1 in self.dims:
             return tune.extract_ir_modules(self.cuda_schedule_reduce_by_warp)
         else:
-            return self.cuda_schedule_reduce_by_default()
+            return tune.extract_ir_modules(self.cuda_schedule_reduce_by_default)
 
     @tune.space(2, use_atomic=[True, False])
     @tune.space(1, use_atomic=[True, False])
@@ -193,7 +193,8 @@ class ReduceTask(Task):
         ir_module = module.ir_module()
         return ir_module
 
-    @tune.space(2, max_block_size=[256, 512, 1024], use_atomic=[True, False])
+    @tune.space(2, max_block_size=[256, 512, 1024], use_atomic=[True])
+    @tune.space(1, max_block_size=[256, 512, 1024], use_atomic=[True])
     def cuda_schedule_reduce_by_default(self, max_block_size=256, use_atomic=True) -> IRModule:
         import hidet
         from hidet.ir.compute import ReduceOperation

--- a/python/hidet/graph/ops/reduce/reduce.py
+++ b/python/hidet/graph/ops/reduce/reduce.py
@@ -222,7 +222,7 @@ class ReduceTask(Task):
             num_eles: int = 4 // xdtype.nbytes
             if shape[-1] % num_eles == 0:
                 lanes = num_eles
-                vtype = VectorType(xdtype, lanes)
+                vtype = vectorize(xdtype, lanes)
 
         read_shape = shape[:]
         read_shape[-1] //= lanes

--- a/python/hidet/graph/ops/reduce/reduce.py
+++ b/python/hidet/graph/ops/reduce/reduce.py
@@ -302,7 +302,7 @@ class ReduceTask(Task):
                 # Init smem
                 if threadIdx.x * lanes < smem_length:
                     for lane in range(lanes):
-                        smem_staging[threadIdx.x + lane] = rv[0]
+                        smem_staging[threadIdx.x * lanes + lane] = rv[0]
 
                 for flat_indices in read_task_mapping.on(threadIdx.x + blockIdx.x * block_size):
                     if flat_indices[0] < remain_extent and flat_indices[1] < reduce_extent:
@@ -337,7 +337,7 @@ class ReduceTask(Task):
                 # At this point, the shared memory contains the final reduction value.
                 # Next, need to write back to global memory
 
-                if threadIdx.x < reduce_warps * WARP_SIZE:
+                if threadIdx.x < remain_warps * WARP_SIZE:
                     for indices in smem_task_mapping.on(threadIdx.x):
                         remain_idx = indices[0]
                         if lanes > 1:

--- a/python/hidet/graph/ops/reduce/resolve.py
+++ b/python/hidet/graph/ops/reduce/resolve.py
@@ -58,7 +58,6 @@ class ReduceResolveRule(ResolveRule):
 
     def resolve_decompose(self, op: Operator) -> Optional[List[Tensor]]:
         dims = op.attrs['dims']
-        keepdims = op.attrs['keepdims']
         x: Tensor = op.inputs[0]
         shape = x.shape
         dims = normalize_dim(dims, len(shape))
@@ -66,7 +65,7 @@ class ReduceResolveRule(ResolveRule):
             # start from highest dim to support keepdims=True
             dims.sort(reverse=True)
             for dim in dims:
-                x = op.reforward([x], {'dims':[dim]})[0]
+                x = op.reforward([x], {'dims': [dim]})[0]
             return [x]
         return None
 

--- a/python/hidet/graph/ops/reduce/resolve.py
+++ b/python/hidet/graph/ops/reduce/resolve.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Callable, Any
 
 from hidet.graph.operator import Operator, Tensor
 from hidet.graph.transforms import ResolveRule, register_resolve_rule
-from hidet.graph.ops.utils import is_contiguous_dims
+from hidet.graph.ops.utils import is_contiguous_dims, normalize_dim
 from hidet.utils import prod
 from .reduce import ReduceBaseOp
 
@@ -56,9 +56,23 @@ class ReduceResolveRule(ResolveRule):
 
         return None
 
+    def resolve_decompose(self, op: Operator) -> Optional[List[Tensor]]:
+        dims = op.attrs['dims']
+        keepdims = op.attrs['keepdims']
+        x: Tensor = op.inputs[0]
+        shape = x.shape
+        dims = normalize_dim(dims, len(shape))
+        if (len(shape) - 1) not in dims and len(dims) > 1:
+            # start from highest dim to support keepdims=True
+            dims.sort(reverse=True)
+            for dim in dims:
+                x = op.reforward([x], {'dims':[dim]})[0]
+            return [x]
+        return None
+
     def resolve(self, op: Operator) -> Optional[List[Tensor]]:
         assert isinstance(op, ReduceBaseOp)
-        resolve_funcs: List[Callable[[Operator], Any]] = [self.resolve_simplify]
+        resolve_funcs: List[Callable[[Operator], Any]] = [self.resolve_simplify, self.resolve_decompose]
         for resolve_func in resolve_funcs:
             outs = resolve_func(op)
             if outs is not None:

--- a/python/hidet/graph/transforms/conv_channel_last.py
+++ b/python/hidet/graph/transforms/conv_channel_last.py
@@ -224,12 +224,18 @@ class ConvChannelLastPass(GraphPass):
         from hidet.ir.dtypes import float16
 
         nodes: List[Operator] = graph.nodes
+<<<<<<< HEAD
         # Start from all fp16 conv2d operators as seeds
         seeds: List[Operator] = []
         for node in nodes:
             if isinstance(node, Conv2dOp):
                 if node.inputs[0].dtype == float16 and node.inputs[1].dtype == float16:
                     seeds.append(node)
+=======
+        # Start from all float16 conv2d operators as seed
+        seeds = [node for node in nodes if (isinstance(
+            node, Conv2dOp) and node.inputs[0].dtype == float16 and node.inputs[1].dtype == float16)]
+>>>>>>> c1c32936 (rid excessive smem)
 
         # Only use this pass if there is convolution in the graph
         if len(seeds) == 0:

--- a/python/hidet/graph/transforms/conv_channel_last.py
+++ b/python/hidet/graph/transforms/conv_channel_last.py
@@ -224,18 +224,12 @@ class ConvChannelLastPass(GraphPass):
         from hidet.ir.dtypes import float16
 
         nodes: List[Operator] = graph.nodes
-<<<<<<< HEAD
         # Start from all fp16 conv2d operators as seeds
         seeds: List[Operator] = []
         for node in nodes:
             if isinstance(node, Conv2dOp):
                 if node.inputs[0].dtype == float16 and node.inputs[1].dtype == float16:
                     seeds.append(node)
-=======
-        # Start from all float16 conv2d operators as seed
-        seeds = [node for node in nodes if (isinstance(
-            node, Conv2dOp) and node.inputs[0].dtype == float16 and node.inputs[1].dtype == float16)]
->>>>>>> c1c32936 (rid excessive smem)
 
         # Only use this pass if there is convolution in the graph
         if len(seeds) == 0:


### PR DESCRIPTION
In some input shapes, the current reduce schedule will underutilize the GPU.
E.g., `reduce [1, 128, 128, 3] , dims=[1, 2]` will spawn 1 threadblock with 3 threads that each iterate over 128*128 elements.
This PR made two changes to optimize these cases:
1. Add resolve_decompose in the resolve logic of Reduce. This will force launch separate kernels for each reduce dimension, increasing concurrency.
2. In the default reduce schedule template, spawn multiple warps within the reduce dimensions, which then will communicate via shared memory or use atomics to perform the reduce.

Also added a resolve rule for AdaptivePoolChannelLast.