### PR TITLE
[Option] Add option to set class Var id attribute to 0 by default

### DIFF
--- a/python/hidet/ir/expr.py
+++ b/python/hidet/ir/expr.py
@@ -19,6 +19,7 @@ import numpy as np
 from .node import Node
 from .type import BaseType, TensorType, DataType, TensorPointerType, PointerType, FuncType, StringType, ArrayType
 from .type import tensor_pointer_type, string_type, tensor_type, data_type
+import hidet.option
 
 PyScalar = Union[bool, int, float, complex, str]
 
@@ -561,7 +562,7 @@ class Var(Expr):
         self.hint: Optional[str] = hint
         self.name: Optional[str] = name
         self.type: Union[BaseType, TensorType, TensorPointerType, FuncType] = type
-        self.id: int = self.new_id()
+        self.id: int = self.new_id() if hidet.option.get_option('debug_show_var_id') else 0
 
     @staticmethod
     def new_id():

--- a/python/hidet/ir/expr.py
+++ b/python/hidet/ir/expr.py
@@ -16,10 +16,10 @@ from typing import Optional, Union, Sequence, Tuple, Dict, Type, Callable
 import string
 import operator
 import numpy as np
+import hidet.option
 from .node import Node
 from .type import BaseType, TensorType, DataType, TensorPointerType, PointerType, FuncType, StringType, ArrayType
 from .type import tensor_pointer_type, string_type, tensor_type, data_type
-import hidet.option
 
 PyScalar = Union[bool, int, float, complex, str]
 

--- a/python/hidet/ir/expr.py
+++ b/python/hidet/ir/expr.py
@@ -562,10 +562,12 @@ class Var(Expr):
         self.hint: Optional[str] = hint
         self.name: Optional[str] = name
         self.type: Union[BaseType, TensorType, TensorPointerType, FuncType] = type
-        self.id: int = self.new_id() if hidet.option.get_option('debug_show_var_id') else 0
+        self.id: int = self.new_id()
 
     @staticmethod
     def new_id():
+        if not hidet.option.get_option('debug_enable_var_id'):
+            return 0
         Var.id_clock += 1
         return Var.id_clock
 

--- a/python/hidet/option.py
+++ b/python/hidet/option.py
@@ -201,7 +201,8 @@ def register_hidet_options():
         name='debug_show_var_id',
         type_hint='bool',
         default_value=False,
-        description='Whether to show the variable id in the IR. Hint: all variable ids will be 0 unless the debug_enable_var_id option is set to True.',
+        description='Whether to show the variable id in the IR.\
+                     Hint: all variable ids will be 0 unless the debug_enable_var_id option is set to True.',
         choices=[True, False],
     )
     register_option(

--- a/python/hidet/option.py
+++ b/python/hidet/option.py
@@ -191,10 +191,17 @@ def register_hidet_options():
         choices=[True, False],
     )
     register_option(
+        name='debug_enable_var_id',
+        type_hint='bool',
+        default_value=False,
+        description='Assign a variable id to each variable in the IR. If set to false, all variable IDs will be 0',
+        choices=[True, False],
+    )
+    register_option(
         name='debug_show_var_id',
         type_hint='bool',
         default_value=False,
-        description='Whether to show the variable id in the IR.',
+        description='Whether to show the variable id in the IR. Hint: all variable ids will be 0 unless the debug_enable_var_id option is set to True.',
         choices=[True, False],
     )
     register_option(
@@ -700,6 +707,19 @@ def debug_cache_tuning(enabled: bool = True):
     """
     OptionContext.current().set_option('debug_cache_tuning', enabled)
 
+def debug_enable_var_id(enable: bool = True):
+    """
+    Whether to enable var id in the IR.
+
+    When this option is enabled, each variable (i.e., hidet.ir.Var) will have a unique id.
+    Otherwise, each variable's ID will be 0.
+
+    Parameters
+    ----------
+    enable: bool
+        Whether to enable var id in the IR.
+    """
+    OptionContext.current().set_option('debug_enable_var_id', enable)
 
 def debug_show_var_id(enable: bool = True):
     """
@@ -707,6 +727,7 @@ def debug_show_var_id(enable: bool = True):
 
     When this option is enabled, the IR will show the var id with the format `var@id`, like `x@1` and `d_1@1732`.
     Variable (i.e., hidet.ir.Var) a and b is the same var if and only if `a is b` evaluates to True in Python).
+    Hint: all variable ids will always be 0 unless the debug_enable_var_id option is set to True.',
 
     Parameters
     ----------

--- a/python/hidet/option.py
+++ b/python/hidet/option.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 from __future__ import annotations
 from typing import Dict, Any, List, Optional, Callable, Iterable, Tuple, Union
+import warnings
 import os
 import tomlkit
 
@@ -730,13 +731,14 @@ def debug_show_var_id(enable: bool = True):
 
     When this option is enabled, the IR will show the var id with the format `var@id`, like `x@1` and `d_1@1732`.
     Variable (i.e., hidet.ir.Var) a and b is the same var if and only if `a is b` evaluates to True in Python).
-    Hint: all variable ids will always be 0 unless the debug_enable_var_id option is set to True.',
 
     Parameters
     ----------
     enable: bool
         Whether to show the var id in the IR.
     """
+    if not OptionContext.current().get_option('debug_enable_var_id'):
+        warnings.warn("Please use `hidet.option.debug_enable_var_id()` to enable the id first")
     OptionContext.current().set_option('debug_show_var_id', enable)
 
 

--- a/python/hidet/option.py
+++ b/python/hidet/option.py
@@ -707,6 +707,7 @@ def debug_cache_tuning(enabled: bool = True):
     """
     OptionContext.current().set_option('debug_cache_tuning', enabled)
 
+
 def debug_enable_var_id(enable: bool = True):
     """
     Whether to enable var id in the IR.
@@ -720,6 +721,7 @@ def debug_enable_var_id(enable: bool = True):
         Whether to enable var id in the IR.
     """
     OptionContext.current().set_option('debug_enable_var_id', enable)
+
 
 def debug_show_var_id(enable: bool = True):
     """


### PR DESCRIPTION
By default Var instances will have an id of 0.

This is to ensure that each entire FlowGraph is entirely deterministic given the same interpreter+input.

