### PR TITLE
[Torch] Implements __torch_func__ protocol

### DIFF
--- a/tests/frontends/torch/test_torch_interoperability.py
+++ b/tests/frontends/torch/test_torch_interoperability.py
@@ -1,0 +1,17 @@
+import pytest
+import torch
+import hidet
+
+
+def test_as_torch_tensor():
+    """
+    test __torch_func__ protocol
+    """
+    a = hidet.randn([32, 32], dtype='float16', device='cuda')
+    b = torch.abs(a)
+    c = hidet.ops.abs(a)
+    torch.testing.assert_close(b, c.torch())
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
This PR implements the `__torch_func__` protocol as suggested at https://pytorch.org/docs/stable/notes/extending.html#extending-torch-with-a-tensor-like-type