### PR TITLE
[Fusion] Allow shallow fusion of cublas operator

### DIFF
--- a/python/hidet/graph/ops/fusion/fused_operator.py
+++ b/python/hidet/graph/ops/fusion/fused_operator.py
@@ -124,7 +124,7 @@ class FusedTask(Task):
         if isinstance(anchor_modules, IRModule):
             anchor_modules = [anchor_modules]
 
-        fused_modules: List[IRModule] = [apply_prologue_epilogue(m, self, working_dir) for m in anchor_modules]
+        fused_modules: List[IRModule] = [apply_prologue_epilogue(m, self, target, working_dir) for m in anchor_modules]
         for fused_module, anchor_module in zip(fused_modules, anchor_modules):
             if hasattr(anchor_module, '_tuning_kwargs'):
                 setattr(fused_module, '_tuning_kwargs', getattr(anchor_module, '_tuning_kwargs'))

--- a/python/hidet/ir/tools/__init__.py
+++ b/python/hidet/ir/tools/__init__.py
@@ -16,5 +16,6 @@ from .free_var_collector import collect_free_vars
 from .printer import IRPrinter, astext
 from .simplifier import simplify, simplify_to_int
 from .hasher import ExprHash
+from .renamer import rename_funcs
 
 # from .ir_dumper import astext2, parse

--- a/python/hidet/ir/tools/renamer.py
+++ b/python/hidet/ir/tools/renamer.py
@@ -1,0 +1,64 @@
+from typing import Dict, List
+from hidet.ir.expr import Var
+from hidet.ir.func import Function
+from hidet.ir.module import IRModule
+from hidet.ir.tools.rewriter import rewrite
+from hidet.ir.tools.util_functors import collect
+
+
+def rename_funcs(ir_module: IRModule, rmap: Dict[str, str]) -> IRModule:
+    """
+    Rename functions in an IRModule.
+
+    Parameters
+    ----------
+    ir_module: IRModule
+        The IRModule.
+    rmap: Dict[str, str]
+        The renaming map.
+
+    Returns
+    -------
+    ret: IRModule
+        The renamed IRModule.
+    """
+    used_vars: List[Var] = collect(ir_module, node_types=Var)
+    func_vars: List[Var] = [v for v in used_vars if v.type.is_func_type()]
+
+    # rename the variables
+    name2var: Dict[str, Var] = {}
+    remap = {}
+    for func_var in func_vars:
+        if func_var.name in rmap:
+            if func_var.name not in name2var:
+                name2var[func_var.name] = Var(hint=None, type=func_var.type, name=rmap[func_var.name])
+            remap[func_var] = name2var[func_var.name]
+
+    ir_module: IRModule = rewrite(ir_module, remap)
+
+    # rename functions
+    new_functions: Dict[str, Function] = {}
+    for name, func in ir_module.functions.items():
+        if name in rmap:
+            new_functions[rmap[name]] = Function(
+                name=rmap[name],
+                params=func.params,
+                body=func.body,
+                ret_type=func.ret_type,
+                kind=func.kind,
+                attrs=func.attrs,
+            )
+        else:
+            new_functions[name] = func
+
+    # rename global vars
+    global_vars: Dict[str, Var] = {}
+    for name, var in ir_module.global_vars.items():
+        if name in rmap:
+            assert var.name == rmap[name]
+            global_vars[rmap[name]] = var
+        else:
+            global_vars[name] = var
+
+    ir_module.reset_funcs(functions=new_functions, global_vars=global_vars)
+    return ir_module


### PR DESCRIPTION
This PR enhance the fusion capability of hidet. Previously, if a task generate an IRModule that can not fuse prologue and epilogue (e.g., there are usage other than TensorElement and BufferStore), hidet will reject to fuse and throw an error. In this PR, we provide a fall back machanism for this case by generating kernels for those prologues and epilogues. With this enhancement, we can use opaque kernels (like cublas) and hidet's kernels in a single search space and enable auto-tuning among vendor's kernels and hidet's kernels.

For the following code
```python
bs, m, n, k = 2, 1024, 1024, 1024
a = hidet.symbol(shape=[bs, m, k], dtype='float32', device='cuda')
b = hidet.randn(shape=[bs, k, n], dtype='float32', device='cuda')

def optimize_and_build(op):
    c = op(a + 1.0, b) + 1.0
    graph = hidet.trace_from(c)
    graph_opt = hidet.graph.optimize(graph)
    compiled = graph_opt.build()
    return compiled

graph_2 = optimize_and_build(hidet.ops.matmul_cublas)
graph_1 = optimize_and_build(hidet.ops.batch_matmul)

a = hidet.randn_like(a)

y1 = graph_1(a)
y2 = graph_2(a)

hidet.utils.assert_close(y1, y2, atol=1e-5, rtol=1e-5)
```
We can generate the fused kernel looks like
```cuda
#include <hidet/runtime/cuda/context.h>
#include <hidet/runtime/logging.h>
#include <hidet/runtime/cuda/cublas.h>


static __global__ void __launch_bounds__(512) hidet_module_0_fused_sub_graph_compute_y(float * __restrict__ x, float * __restrict__ y) {
  y[(((((((int)blockIdx.x * 512) + (int)threadIdx.x) / 1048576) * 1048576) + ((((((int)blockIdx.x * 512) + (int)threadIdx.x) / 1024) % 1024) * 1024)) + ((((int)blockIdx.x * 512) + (int)threadIdx.x) % 1024))] = (x[(((((((int)blockIdx.x * 512) + (int)threadIdx.x) / 1048576) * 1048576) + ((((((int)blockIdx.x * 512) + (int)threadIdx.x) / 1024) % 1024) * 1024)) + ((((int)blockIdx.x * 512) + (int)threadIdx.x) % 1024))] + 1.0f);
}

static __global__ void __launch_bounds__(512) hidet_module_2_fused_sub_graph_compute_y(float * __restrict__ x, float * __restrict__ y) {
  y[(((((((int)blockIdx.x * 512) + (int)threadIdx.x) / 1048576) * 1048576) + ((((((int)blockIdx.x * 512) + (int)threadIdx.x) / 1024) % 1024) * 1024)) + ((((int)blockIdx.x * 512) + (int)threadIdx.x) % 1024))] = (x[(((((((int)blockIdx.x * 512) + (int)threadIdx.x) / 1048576) * 1048576) + ((((((int)blockIdx.x * 512) + (int)threadIdx.x) / 1024) % 1024) * 1024)) + ((((int)blockIdx.x * 512) + (int)threadIdx.x) % 1024))] + 1.0f);
}

DLL void hidet_module_0_launch(float * __restrict__ x, float * __restrict__ y) {
  hidet_module_0_fused_sub_graph_compute_y<<<dim3(16384, 1, 1), dim3(512, 1, 1), 0, (cudaStream_t)get_cuda_stream()>>>(x, y);
  {cudaError_t err = cudaGetLastError(); if (err != cudaSuccess) LOG(ERROR) << "CUDA error: " << cudaGetErrorString(err) << "\n";}
}

DLL void hidet_module_1_launch(float * __restrict__ a, float * __restrict__ b, float * __restrict__ c) {
  hidet_cublas_strided_gemm(8, 1024, 1024, 1024, 0, 0, 0, a, b, c, 1048576, 1048576, 1048576, false, false, 68);
}

DLL void hidet_module_2_launch(float * __restrict__ x, float * __restrict__ y) {
  hidet_module_2_fused_sub_graph_compute_y<<<dim3(16384, 1, 1), dim3(512, 1, 1), 0, (cudaStream_t)get_cuda_stream()>>>(x, y);
  {cudaError_t err = cudaGetLastError(); if (err != cudaSuccess) LOG(ERROR) << "CUDA error: " << cudaGetErrorString(err) << "\n";}
}

DLL void hidet_launch_0(float * __restrict__ p, float * __restrict__ p_1, float * __restrict__ p_2) {
  float *buf;
  float *buf_1;
  uint8_t *workspace;
  workspace = ((uint8_t*)(request_cuda_workspace(int64_t(67108864ll), false)));
  buf = ((float*)((&workspace[int64_t(0ll)])));
  buf_1 = ((float*)((&workspace[int64_t(33554432ll)])));
  hidet_module_0_launch(p_1, buf);
  hidet_module_1_launch(buf, p, buf_1);
  hidet_module_2_launch(buf_1, p_2);
}
```