### PR TITLE
[Compilation] Optimization for compilation process

### DIFF
--- a/apps/compile_server/resources/compile_worker.py
+++ b/apps/compile_server/resources/compile_worker.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Sequence, Union
 import os
 import traceback
 import argparse
@@ -51,7 +51,7 @@ def compile_job(job_id: str):
 
             # load the workload
             workload: Dict[str, Any] = pickle.loads(job['workload'])
-            ir_module: hidet.ir.IRModule = workload['ir_module']
+            ir_module: Union[hidet.ir.IRModule, Sequence[hidet.ir.IRModule]] = workload['ir_module']
             target: str = workload['target']
             output_kind: str = workload['output_kind']
 

--- a/python/hidet/apps/compile_server/compilation.py
+++ b/python/hidet/apps/compile_server/compilation.py
@@ -9,6 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Sequence, Union
 import zipfile
 import shutil
 import tempfile
@@ -21,7 +22,9 @@ from hidet.ir.module import IRModule
 from .core import api_url, access_token
 
 
-def remote_build(ir_module: IRModule, output_dir: str, *, target: str, output_kind: str = '.so'):
+def remote_build(
+    ir_module: Union[IRModule, Sequence[IRModule]], output_dir: str, *, target: str, output_kind: str = '.so'
+):
     # upload the IRModule
     if 'cuda' in target:
         if 'arch' not in target:

--- a/python/hidet/drivers/build_module.py
+++ b/python/hidet/drivers/build_module.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Sequence, Dict
+from typing import Sequence, Dict, Union
 import logging
 import os
 import pickle
@@ -34,10 +34,20 @@ logger.addHandler(logging.StreamHandler())
 
 
 def can_remote_build(ir_module: IRModule) -> bool:
-    return not (len(ir_module.object_files) > 0 or len(ir_module.linking_dirs) > 0 or len(ir_module.include_dirs) > 0)
+    def can_remote_single_build(ir_module: IRModule) -> bool:
+        return not (
+            len(ir_module.object_files) > 0 or len(ir_module.linking_dirs) > 0 or len(ir_module.include_dirs) > 0
+        )
+
+    if isinstance(ir_module, IRModule):
+        return can_remote_single_build(ir_module)
+    else:
+        return all(can_remote_single_build(m) for m in ir_module)
 
 
-def build_ir_module(ir_module: IRModule, output_dir: str, *, target: str, output_kind: str = '.so', force=False):
+def build_ir_module(
+    ir_module: Union[IRModule, Sequence[IRModule]], output_dir: str, target: str, output_kind: str = '.so', force=False
+):
     """
     Build an IR module to a shared library or object file.
 
@@ -50,8 +60,8 @@ def build_ir_module(ir_module: IRModule, output_dir: str, *, target: str, output
 
     Parameters
     ----------
-    ir_module: IRModule
-        The IR module to be built.
+    ir_module: Union[IRModule, Sequence[IRModule]]
+        The IR module to be built. This can be a single IRModule or a sequence of IRModules.
 
     output_dir: str
         The directory to save the generated source code and the compiled library.
@@ -118,20 +128,39 @@ def build_ir_module(ir_module: IRModule, output_dir: str, *, target: str, output
         if target.name == 'cpu' and 'arch' in target.attrs:
             hidet.option.cpu.arch(target.attrs['arch'])
         with PassContext(instruments=instruments):
-            ir_module = lower(ir_module)
+            if isinstance(ir_module, Sequence):
+                for i in range(len(ir_module)):
+                    ir_module[i] = lower(ir_module[i])
+            else:
+                ir_module = lower(ir_module)
 
     # code generation
     codegen(ir_module, src_out_path=src_path, target=target)
 
+    include_dir = []
+    linking_dir = []
+    linking_lib = []
+    object_file = []
+    if isinstance(ir_module, Sequence):
+        for im in ir_module:
+            include_dir.extend(im.include_dirs)
+            linking_dir.extend(im.linking_dirs)
+            linking_lib.extend(im.linking_libs)
+            object_file.extend(im.object_files)
+    else:
+        include_dir.extend(ir_module.include_dirs)
+        linking_dir.extend(ir_module.linking_dirs)
+        linking_lib.extend(ir_module.linking_libs)
+        object_file.extend(ir_module.object_files)
     # compile source code
     compile_source(
         src_path,
         output_library_file=lib_path,
         target=target,
-        include_dirs=ir_module.include_dirs,
-        linking_dirs=ir_module.linking_dirs,
-        linking_libraries=ir_module.linking_libs,
-        object_files=ir_module.object_files,
+        include_dirs=include_dir,
+        linking_dirs=linking_dir,
+        linking_libraries=linking_lib,
+        object_files=object_file,
     )
 
     # write the function types
@@ -154,8 +183,8 @@ def build_ir_module_batch(
     ir_modules: Sequence[IRModule]
         A sequence of ir modules to build.
 
-    output_dirs: Sequence[str]
-        The output directory to save the compiled library and source code (lib.so and source.cu).
+    output_dirs: Squence[str]
+        Directories for compilation artifacts
 
     output_kind: str
         The output kind of the compiled library. Can be '.so' or '.o'.
@@ -172,19 +201,23 @@ def build_ir_module_batch(
         ir_module, output_dir = args
         build_ir_module(ir_module, output_dir, output_kind=output_kind, target=target, force=force)
 
-    jobs = [(ir_module, output_dir) for ir_module, output_dir in zip(ir_modules, output_dirs)]
+    def regroup_modules(modules, size):
+        if size > 1:
+            return [modules[i : i + size] for i in range(0, len(modules), size)]
+        else:
+            return modules
 
     # calculate the number of workers
     cpu_count = os.cpu_count()
     if hidet.option.compile_server.enabled():
-        num_workers = min(len(jobs), 128)
+        num_workers = min(len(ir_modules), 128)
     else:
         max_jobs, mem_for_worker = option.get_parallel_tune()
         max_jobs = cpu_count if max_jobs == -1 else min(max_jobs, cpu_count)
         mem_for_worker *= 1024**3
         num_workers = min(max(int(psutil.virtual_memory().available // mem_for_worker), 1), max_jobs)
 
-    if num_workers > 1 and len(jobs) > 1:
+    if num_workers > 1 and len(ir_modules) > 1:
         # Set the affinity of current process. Some package such as numpy will change affinity of current process,
         # which might limit the parallelism of compilation.
         from contextlib import suppress
@@ -194,9 +227,16 @@ def build_ir_module_batch(
 
         lazy_initialize_cuda()
 
+        per_worker_jobs = 1 if len(ir_modules) < num_workers else len(ir_modules) // num_workers
+        ir_modules_list = regroup_modules(ir_modules, per_worker_jobs)
+        jobs = [
+            (ir_modules, output_dir)
+            for ir_modules, output_dir in zip(ir_modules_list, output_dirs[: len(ir_modules_list)])
+        ]
+
         for _ in tqdm(parallel_imap(build_job, jobs, num_workers), desc='Compiling', total=len(jobs), ncols=80):
             pass
+        return output_dirs[: len(ir_modules_list)]
     else:
-        # sequential build
-        for job in tqdm(jobs, desc='Compiling', ncols=80, disable=len(jobs) == 1):
-            build_job(job)
+        build_ir_module(ir_modules, output_dir=output_dirs[0], output_kind=output_kind, target=target, force=force)
+        return [output_dirs[0]]


### PR DESCRIPTION
optimize the compilation behavior for each core. Instead of generating a cuda source file for each core, congragate them into a single source file to reduce compilation overhead.

Initial test reveals a 20% decrease in the total compilation+run time of bert model (222s -> 177s). Also the same percentage of decrease in operator tests.