### PR TITLE
transpose 2d v1

### DIFF
--- a/.github/scripts/bench/bench_op.py
+++ b/.github/scripts/bench/bench_op.py
@@ -42,6 +42,16 @@ def bench_conv2d(params: str, *args, **kwargs) -> float:
     g = g.cuda_graph()
     return bench_torch_model(lambda: g.run_async(), [])
 
+def bench_transpose2d(params: str, *args, **kwargs) -> float:
+    x_shape = params
+    x_shape = [int(s) for s in x_shape.split('x')]
+    x = hidet.symbol(x_shape, dtype='float32', device='cuda')
+    o = hidet.ops.transpose(x)
+    g = hidet.trace_from(o, inputs=[x])
+    g = hidet.graph.optimize(g)
+    g = g.cuda_graph()
+    return bench_torch_model(lambda: g.run_async(), [])
+
 def bench_conv2d_gemm_f16(params: str, *args, **kwargs) -> float:
     x_shape, w_shape = params.split(',')
     x_shape = [int(s) for s in x_shape.split('x')]
@@ -101,6 +111,7 @@ bench_func_map = {
     'matmul_f16': bench_matmul_f16,
     'batch_matmul': bench_batch_matmul,
     'conv2d': bench_conv2d,
+    'transpose2d' : bench_transpose2d,
     'conv2d_gemm_f16': bench_conv2d_gemm_f16,
     'attn': bench_attn,
     'attn_mask_add': bench_attn_mask_add,

--- a/tests/operators/test_transform.py
+++ b/tests/operators/test_transform.py
@@ -87,6 +87,11 @@ def test_transpose(shape, axes):
     check_transform(shape, lambda x: np.transpose(x, axes), lambda x: ops.transpose(x, axes))
 
 
+@pytest.mark.parametrize("shape", [[33, 44], [1, 100], [100, 1], [10, 20], [20, 10], [100, 200], [2000, 3000]])
+def test_transpose_2d(shape):
+    check_transform(shape, lambda x: np.transpose(x), lambda x: ops.transpose(x))
+
+
 @pytest.mark.parametrize(
     "shapes, dtype, axis",
     [


### PR DESCRIPTION
This is a special version for the current transpose operator. The current transpose operator will handle a general N-dimension transpose, while this PR implement a 2D version to speed up 2D transpose.
Thread coarsening and (static) shared memory have been used. 
Benchmark result:
```
Running command: python /home/zhiwei/hidet/.github/scripts/bench/bench_op.py transpose2d --params 3000x4000 --dtype float16
type        id  name         runfile        param_id  param_name      dtype_id  dtype_name    hardware_config      latency
--------  ----  -----------  -----------  ----------  ------------  ----------  ------------  -----------------  ---------
operator     3  transpose2d  bench_op.py           7  3000x4000              1  float16                           0.181748

```