### PR TITLE
[Dynamo] Refactor get_wrapper and pickling compiled graph

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,4 +1,4 @@
 mysql-connector-python
-transformers
+transformers==4.37
 accelerate
 sentencepiece

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   format-and-lint:
-    if: github.repository == 'hidet-org/hidet'
+    if: github.repository == 'hidet-org/hidet' || github.repository == 'CentML/hidet'
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -162,7 +162,7 @@ jobs:
           CI_DB_PASSWORD: ${{ secrets.CI_DB_PASSWORD }}
 
   stop_instances:
-    if: inputs.shutdown_instances
+    if: ${{ always() && inputs.shutdown_instances }}
     runs-on: ubuntu-latest
     needs: [start_instances, run_tests]
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Run tests
         run: |
+          rm -rf ~/.config/hidet
           python -m pytest -v --durations=20 --clear-cache ./tests
 
       # Build the docs

--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# Ignore VSCode files 
+.vscode/*
+
 # pycharm line profiler result
 **/*.pclprof
 

--- a/apps/compile_server/resources/compile_worker.py
+++ b/apps/compile_server/resources/compile_worker.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Sequence, Union
 import os
 import traceback
 import argparse
@@ -51,7 +51,7 @@ def compile_job(job_id: str):
 
             # load the workload
             workload: Dict[str, Any] = pickle.loads(job['workload'])
-            ir_module: hidet.ir.IRModule = workload['ir_module']
+            ir_module: Union[hidet.ir.IRModule, Sequence[hidet.ir.IRModule]] = workload['ir_module']
             target: str = workload['target']
             output_kind: str = workload['output_kind']
 

--- a/python/hidet/apps/compile_server/compilation.py
+++ b/python/hidet/apps/compile_server/compilation.py
@@ -9,6 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Sequence, Union
 import zipfile
 import shutil
 import tempfile
@@ -21,7 +22,9 @@ from hidet.ir.module import IRModule
 from .core import api_url, access_token
 
 
-def remote_build(ir_module: IRModule, output_dir: str, *, target: str, output_kind: str = '.so'):
+def remote_build(
+    ir_module: Union[IRModule, Sequence[IRModule]], output_dir: str, *, target: str, output_kind: str = '.so'
+):
     # upload the IRModule
     if 'cuda' in target:
         if 'arch' not in target:

--- a/python/hidet/graph/frontend/torch/dynamo_backends.py
+++ b/python/hidet/graph/frontend/torch/dynamo_backends.py
@@ -97,7 +97,6 @@ def get_compiled_graph(flow_graph: FlowGraph):
     logger.info('finish building computation graph')
     return cgraph
 
-
 def preprocess_inputs(inputs: Sequence[torch.Tensor]) -> List[hidet.Tensor]:
     torch_inputs: List[torch.Tensor] = []
     for x in inputs:
@@ -115,7 +114,7 @@ class CompiledForwardFunction(torch.nn.Module):
         self.inputs = inputs
         self.output_format = output_format
 
-    def __call__(self, *args):
+    def forward(self, *args):
         if dynamo_config['use_cuda_graph']:
             try:
                 runner = self.cgraph.cuda_graph()
@@ -136,8 +135,8 @@ class CompiledForwardFunction(torch.nn.Module):
             else:
                 # ignore constant
                 pass
-
-        hidet_inputs = preprocess_inputs(self.inputs)
+        
+        hidet_inputs = preprocess_inputs(tensor_args)
         hidet_outputs: List[hidet.Tensor] = runner.run_async(hidet_inputs)
         outputs: Sequence[torch.Tensor] = [tensor.torch() for tensor in hidet_outputs]
         return deserialize_output(self.output_format, outputs)

--- a/python/hidet/graph/frontend/torch/dynamo_backends.py
+++ b/python/hidet/graph/frontend/torch/dynamo_backends.py
@@ -110,10 +110,10 @@ def preprocess_inputs(inputs: Sequence[torch.Tensor]) -> List[hidet.Tensor]:
 
 class CompiledForwardFunction(torch.nn.Module): 
     def __init__(self, cgraph: CompiledGraph, inputs, output_format):
+        super().__init__()
         self.cgraph = cgraph
         self.inputs = inputs
         self.output_format = output_format
-
 
     def __call__(self, *args):
         if dynamo_config['use_cuda_graph']:

--- a/python/hidet/graph/frontend/torch/register_functions.py
+++ b/python/hidet/graph/frontend/torch/register_functions.py
@@ -30,7 +30,7 @@ Number = Union[int, float, bool]
 
 
 @register_function(torch.nn.functional.conv1d)
-def conv1d(x: Tensor, weight: Tensor, bias: Optional[Tensor], stride, padding, dilation, groups):
+def conv1d(x: Tensor, weight: Tensor, bias: Optional[Tensor] = None, stride=1, padding=0, dilation=1, groups=1):
     x = ops.conv_pad(x, padding)
     y = ops.conv1d(x, weight, stride=stride, dilations=dilation, groups=groups)
     if bias is not None:
@@ -40,7 +40,14 @@ def conv1d(x: Tensor, weight: Tensor, bias: Optional[Tensor], stride, padding, d
 
 @register_function(torch.nn.functional.conv_transpose1d)
 def conv1d_transpose(
-    x: Tensor, weight: Tensor, bias: Optional[Tensor], stride, padding, output_padding, groups, dilation
+    x: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor] = None,
+    stride=1,
+    padding=0,
+    output_padding=0,
+    groups=1,
+    dilation=1,
 ):
     if dilation != 1 and not same_list(dilation, [1]):
         raise NotImplementedError("dilation != 1")
@@ -51,7 +58,7 @@ def conv1d_transpose(
 
 
 @register_function(torch.nn.functional.conv2d)
-def conv2d(x: Tensor, weight: Tensor, bias: Optional[Tensor], stride, padding, dilation, groups):
+def conv2d(x: Tensor, weight: Tensor, bias: Optional[Tensor] = None, stride=1, padding=0, dilation=1, groups=1):
     y = ops.conv2d(x, weight, stride, dilation, groups, padding=padding)
     if bias is not None:
         y = y + ops.unsqueeze(bias, [0, 2, 3])
@@ -60,7 +67,7 @@ def conv2d(x: Tensor, weight: Tensor, bias: Optional[Tensor], stride, padding, d
 
 @register_function(torch.nn.functional.conv_transpose2d)
 def conv2d_transpose(
-    x: Tensor, weight: Tensor, bias: Optional[Tensor], stride, padding, output_padding, groups, dilation
+    x: Tensor, weight: Tensor, bias: Optional[Tensor], stride=1, padding=0, output_padding=0, groups=1, dilation=1
 ):
     if dilation != 1 and not same_list(dilation, [1, 1]):
         raise NotImplementedError("dilation != 1")
@@ -71,7 +78,7 @@ def conv2d_transpose(
 
 
 @register_function(torch.nn.functional.conv3d)
-def conv3d(x: Tensor, weight: Tensor, bias: Optional[Tensor], stride, padding, dilation, groups):
+def conv3d(x: Tensor, weight: Tensor, bias: Optional[Tensor] = None, stride=1, padding=0, dilation=1, groups=1):
     x = ops.conv_pad(x, padding)
     y = ops.conv3d(x, weight, stride, dilation, groups)
     if bias is not None:
@@ -81,7 +88,14 @@ def conv3d(x: Tensor, weight: Tensor, bias: Optional[Tensor], stride, padding, d
 
 @register_function(torch.nn.functional.conv_transpose3d)
 def conv3d_transpose(
-    x: Tensor, weight: Tensor, bias: Optional[Tensor], stride, padding, output_padding, groups, dilation
+    x: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor] = None,
+    stride=1,
+    padding=0,
+    output_padding=0,
+    groups=1,
+    dilation=1,
 ):
     if dilation != 1 and not same_list(dilation, [1, 1, 1]):
         raise NotImplementedError("dilation != 1")

--- a/python/hidet/graph/frontend/torch/register_methods.py
+++ b/python/hidet/graph/frontend/torch/register_methods.py
@@ -63,6 +63,16 @@ def tensor_type_as(self: Tensor, other: Tensor) -> Tensor:
     return ops.cast(self, other.dtype)
 
 
+@register_method(torch.Tensor.index_select)
+def index_select(self: Tensor, dim: int, index: Tensor):
+    return ops.index_select(self, index, dim)
+
+
+@register_method(torch.Tensor.fill_)
+def fill_(self: Tensor, value):
+    return ops.full(self.shape, value, dtype=self.dtype, device=self.device)
+
+
 @register_method(torch.Tensor.to)
 def tensor_to(self: Tensor, *args, **kwargs) -> Tensor:
     """

--- a/python/hidet/graph/nn/norms.py
+++ b/python/hidet/graph/nn/norms.py
@@ -62,3 +62,25 @@ class LayerNorm(Module):
         if self.bias is not None:
             x = x + self.bias
         return x
+
+
+class GroupNorm(Module):
+    def __init__(self, num_groups, num_channels, eps=1e-5, affine=True):
+        super().__init__()
+        self.eps = eps
+        self.affine = affine
+        self.num_groups = num_groups
+        self.num_channels = num_channels
+        if affine:
+            self.weight: Tensor = empty(shape=[num_channels])
+            self.bias: Tensor = empty(shape=[num_channels])
+        else:
+            self.weight = None
+            self.bias = None
+
+    def forward(self, x: Tensor):
+        x = ops.group_norm(x, self.num_groups, self.eps)
+        if self.affine:
+            x = x * self.weight + self.bias
+
+        return x

--- a/python/hidet/graph/ops/__init__.py
+++ b/python/hidet/graph/ops/__init__.py
@@ -41,7 +41,7 @@ from .quant import symmetric_quantize, symmetric_dequantize
 from .reduce import mean, sum, var, min, max, std, prod, argmin, argmax, all, any
 from .cumulative import cumsum
 from .transform import squeeze, unsqueeze, flatten, concat, cast, take, rearrange, strided_slice, reshape
-from .transform import transpose, broadcast, pad, tile, split, conv_pad, expand_dims, gather
+from .transform import transpose, broadcast, pad, tile, split, conv_pad, expand_dims, gather, index_select
 from .transform import permute_dims
 from .fusion import fused_operator
 from .transfer import transfer

--- a/python/hidet/graph/ops/conv2d/conv2d.py
+++ b/python/hidet/graph/ops/conv2d/conv2d.py
@@ -12,7 +12,14 @@
 from typing import List, Union, Sequence
 from hidet import ir
 from hidet.graph.ops.utils import Task, Operator, Tensor, TensorNode
-from hidet.graph.ops.utils import compute, input_like, normalize_stride, normalize_dilations, reduce
+from hidet.graph.ops.utils import (
+    compute,
+    input_like,
+    normalize_stride,
+    normalize_dilations,
+    normalize_conv_padding,
+    reduce,
+)
 from hidet.utils.py import cdiv
 
 
@@ -147,6 +154,7 @@ class Conv2dOp(Operator):
     ):
         stride = normalize_stride(stride)
         dilations = normalize_dilations(dilations)
+        padding = normalize_conv_padding(padding, 2)
         super().__init__(
             inputs=[x, w],
             attributes={'padding': padding, 'stride': stride, 'groups': groups, 'dilations': dilations},

--- a/python/hidet/graph/ops/reduce/reduce.py
+++ b/python/hidet/graph/ops/reduce/reduce.py
@@ -398,7 +398,14 @@ class ArgReduceTask(Task):
 
 
 class ReduceBaseOp(Operator):
-    def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keep_dim: bool, reduce_type: str):
+    def __init__(
+        self,
+        x: Tensor,
+        dims: Optional[Sequence[int]],
+        keep_dim: bool,
+        reduce_type: str,
+        accumulate_dtype: str = 'float32',
+    ):
         rank = len(x.shape)
         if dims is None:
             dims = list(range(rank))
@@ -406,7 +413,7 @@ class ReduceBaseOp(Operator):
         super().__init__(
             inputs=[x],
             attributes={'dims': dims, 'keepdims': keep_dim},
-            task=ReduceTask(input_like(x, 'x'), dims, keep_dim, reduce_type),
+            task=ReduceTask(input_like(x, 'x'), dims, keep_dim, reduce_type, accumulate_dtype=accumulate_dtype),
         )
 
 
@@ -444,12 +451,12 @@ class ReduceMinOp(ReduceBaseOp):
 
 class ReduceOrOp(ReduceBaseOp):
     def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keepdims: bool = False):
-        super().__init__(x, dims, keepdims, ReduceType.Or.value)
+        super().__init__(x, dims, keepdims, ReduceType.Or.value, 'bool')
 
 
 class ReduceAndOp(ReduceBaseOp):
     def __init__(self, x: Tensor, dims: Optional[Sequence[int]], keepdims: bool = False):
-        super().__init__(x, dims, keepdims, ReduceType.And.value)
+        super().__init__(x, dims, keepdims, ReduceType.And.value, 'bool')
 
 
 class ReduceProdOp(ReduceBaseOp):

--- a/python/hidet/graph/ops/utils/tensor_utils.py
+++ b/python/hidet/graph/ops/utils/tensor_utils.py
@@ -92,6 +92,15 @@ def normalize_padding(padding: Union[Int, Sequence[Int]], dim=2) -> List[Int]:
     )
 
 
+def normalize_conv_padding(padding: Union[Int, Sequence[Int]], dim) -> List[Int]:
+    if isinstance(padding, int):
+        return [padding for _ in range(dim)]
+    elif isinstance(padding, (list, tuple)):
+        assert len(padding) == dim
+        return padding
+    raise ValueError('Incorrect conv padding: {}; dim is {}'.format(padding, dim))
+
+
 def normalize_dim(dim: Optional[Union[Int, Sequence[Int]]], rank: int) -> Union[Int, List[Int]]:
     """
     normalize a dim from [-rank, rank] or None to [0, rank].

--- a/python/hidet/ir/primitives/cuda/smem.py
+++ b/python/hidet/ir/primitives/cuda/smem.py
@@ -24,7 +24,7 @@ from hidet.utils import initialize
 def register_functions():
     from hidet.lang import script, attrs, cast
 
-    for dtype in ['int8', 'uint8', 'uint32', 'int32', 'float16', 'float32']:
+    for dtype in ['int8', 'uint8', 'uint32', 'int32', 'float16', 'float32', 'bool']:
         func_name = f'cuda_dynamic_shared_memory_{dtype}'
         dtype = data_type(dtype)
 

--- a/python/hidet/runtime/compiled_graph.py
+++ b/python/hidet/runtime/compiled_graph.py
@@ -136,6 +136,23 @@ class CompiledGraph:
             # the weights are already loaded, initialize the graph directly
             self._init_compiled_graph()
 
+    def __getstate__(self):
+        # Create a temporary file and save the CompiledGraph zip in it
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            self.save(temp_file.name)
+            with open(temp_file.name, 'rb') as f:
+                state = f.read()
+        # os.unlink(temp_file.name)  # Delete the temporary file
+        return state
+
+    def __setstate__(self, state):
+        # Load the CompiledGraph
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            with open(temp_file.name, 'wb') as f:
+                f.write(state)
+            self.load(temp_file.name)
+        # os.unlink(temp_file.name)  # Delete the temporary file
+
     def __str__(self):
         """
         Get the basic information of this compiled graph.
@@ -499,6 +516,21 @@ class CompiledGraph:
             Whether to save the dispatch table to disk. See `save_compiled_graph` for details.
         """
         save_compiled_graph(self, path, save_dispatch_table)
+
+    def load(self, path: str):
+        """
+        Set the state of self to the state of the CompiledGraph saved in the given file.
+
+        See Also
+        --------
+        CompiledGraph.save or save_compiled_graph
+        
+        Parameters
+        ----------
+        path: str
+            The path to save the compiled graph. By convention, the path should end with '.hidet'
+        """
+        self.__dict__.update(load_compiled_graph(path).__dict__)
 
 
 def save_compiled_graph(model: CompiledGraph, file: str, save_dispatch_table: bool = False, save_weights: bool = True):

--- a/python/hidet/runtime/compiled_graph.py
+++ b/python/hidet/runtime/compiled_graph.py
@@ -66,7 +66,7 @@ class GraphExecution:
     outputs_index: List[int]
     tensor_device: List[str]
 
-
+import sys
 class CompiledGraph:
     """
     A compiled graph that can be directly called in Python.
@@ -138,20 +138,18 @@ class CompiledGraph:
 
     def __getstate__(self):
         # Create a temporary file and save the CompiledGraph zip in it
-        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-            self.save(temp_file.name)
+        with tempfile.NamedTemporaryFile() as temp_file:
+            self.save(temp_file.name, save_dispatch_table=True)
             with open(temp_file.name, 'rb') as f:
                 state = f.read()
-        # os.unlink(temp_file.name)  # Delete the temporary file
         return state
 
     def __setstate__(self, state):
         # Load the CompiledGraph
-        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        with tempfile.NamedTemporaryFile() as temp_file:
             with open(temp_file.name, 'wb') as f:
                 f.write(state)
             self.load(temp_file.name)
-        # os.unlink(temp_file.name)  # Delete the temporary file
 
     def __str__(self):
         """

--- a/python/hidet/runtime/compiled_graph.py
+++ b/python/hidet/runtime/compiled_graph.py
@@ -66,7 +66,8 @@ class GraphExecution:
     outputs_index: List[int]
     tensor_device: List[str]
 
-import sys
+
+
 class CompiledGraph:
     """
     A compiled graph that can be directly called in Python.
@@ -522,7 +523,7 @@ class CompiledGraph:
         See Also
         --------
         CompiledGraph.save or save_compiled_graph
-        
+
         Parameters
         ----------
         path: str

--- a/python/hidet/runtime/compiled_graph.py
+++ b/python/hidet/runtime/compiled_graph.py
@@ -67,7 +67,6 @@ class GraphExecution:
     tensor_device: List[str]
 
 
-
 class CompiledGraph:
     """
     A compiled graph that can be directly called in Python.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ pylint==2.13.9
 # for models to test
 torch
 torchvision
-transformers
+transformers==4.37
 sentencepiece
 sacremoses
 


### PR DESCRIPTION
The CentML compilation backend I am working on wants to wrap the `CompiledGraph`s forward function (the one returned by `get_wrapper`) in a `torch.fx.GraphModule`. This `GraphModule` would then be pickled and sent from a server to a client.

However, it isn't possible to pickle the lambda/local function returned by `get_wrapper`. Therefore, I am turning `get_wrapper` into a class `CompiledForwardFunction` whose `forward` function behaves like the `wrapper` returned by `get_wrapper`.

Additionally, in order to pickle `CompiledForwardFunction`, I have defined pickling and unpickling behaviour for `CompiledGraph` using `__getstate__` and `__setstate__` respectively. These just call `CompiledGraph`'s existing `save` and `load` functions.