### PR TITLE
[Fix] Skip a failed test due to huggingface transformers update

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ pylint==2.13.9
 # for models to test
 torch
 torchvision
-transformers
+transformers==4.37
 sentencepiece
 sacremoses
 

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -65,6 +65,7 @@ def test_llama2(device, opt):
     print(current_memory_pool("vcuda"))
 
 
+@pytest.mark.skip(reason='The transformers updated their modeling, skip until we update.')
 def test_model_architecture():
     import torch
     import hidet

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -65,7 +65,6 @@ def test_llama2(device, opt):
     print(current_memory_pool("vcuda"))
 
 
-@pytest.mark.skip(reason='The transformers updated their modeling, skip until we update.')
 def test_model_architecture():
     import torch
     import hidet


### PR DESCRIPTION
Fix the transformers version to 4.37 to pass the CI (the new version of transformers introduced some breaking change).

Todo: update our modeling to make it compatible with the new version of transformers.