### PR TITLE
fix overload methods

### DIFF
--- a/python/hidet/graph/frontend/torch/interpreter.py
+++ b/python/hidet/graph/frontend/torch/interpreter.py
@@ -132,7 +132,7 @@ def register_function(func: Union[Callable, str]):
 
 def register_method(method: Callable):
     def decorator(hidet_method):
-        if method not in Registry.registered_functions:
+        if method not in Registry.registered_methods:
             Registry.registered_methods[method] = OverloadedFunction()
         Registry.registered_methods[method].overload(hidet_method)
         return hidet_method


### PR DESCRIPTION
When overloading, should check `registered_methods` instead of functions, or it will cause not implement error