### PR TITLE
feat: move release workflow test to internal arc runners

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,6 +1,7 @@
 name: Publish to PyPI
 
 on:
+  pull_request:
   release:
     types: [published]
 
@@ -11,19 +12,53 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    runs-on: [self-hosted, Linux, X64, gpu]
+    runs-on: arc-runner-set
     container:
       image: nvcr.io/nvidia/pytorch:24.04-py3
-      options: --gpus all
     steps:
       - name: Install dependencies via apt
         run: |
           apt update && DEBIAN_FRONTEND=noninteractive apt install -y ccache git graphviz
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.19.x'
+
+      - name: Setup Hidet
+        uses: ./.github/actions/setup-hidet
+  
+      - name: List installed packages
+        run: |
+          pip list
+
+      # Run tests
+      - name: Run tests
+        run: |
+          python -m pytest -v --durations=20 --clear-cache ./tests
+
+
+  build-docs:
+    if: github.repository == 'hidet-org/hidet'
+    runs-on: arc-runner-set
+    container:
+      image: nvcr.io/nvidia/pytorch:24.04-py3
+    steps:
+      - name: Install dependencies via apt
+        run: |
+          apt update && DEBIAN_FRONTEND=noninteractive apt install -y ccache git graphviz
+
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
 
@@ -32,43 +67,24 @@ jobs:
         with:
           cmake-version: '3.19.x'
 
-      - name: Install dependencies via pip
+      - name: Setup Hidet
+        uses: ./.github/actions/setup-hidet
+  
+      - name: List installed packages
         run: |
-          python -m pip install --upgrade pip
-          pip install torch torchvision torchaudio 
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
-
-      - name: Build hidet
-        run: |
-          bash scripts/wheel/build_wheel.sh
-          WHEEL=$(find ./scripts/wheel/built_wheel -maxdepth 1 -name '*.whl')
-          echo "WHEEL_NAME=$WHEEL" >> $GITHUB_ENV
-          echo "Built wheel: ${{ env.WHEEL_NAME }}"
-
-      - name: Install hidet
-        run: |
-          pip install --no-deps --force-reinstall ${{ env.WHEEL_NAME }}
-
-      # Run tests
-
-      - name: Run tests with operator cache cleared
-        run: |
-          python -m pytest -v --durations=20 --clear-cache ./tests
-
-      # Build the docs
+          pip list
 
       - name: Install docs dependencies
         run: |
           pip install -r docs/requirements.txt
-
+    
       - name: Build docs
         run: |
           cd docs; make clean; make html
 
   publish:
     name: Publish to PyPI
-    needs: [publish-tests] # require tests to pass before deploy runs
+    needs: [publish-tests, build-docs] # require tests to pass before deploy runs
     if: github.event_name == 'release' && github.event.action == 'published' && startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Install docs dependencies
         run: |
           pip install -r docs/requirements.txt
-    
+
       - name: Build docs
         run: |
           cd docs; make clean; make html

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -6,12 +6,36 @@ on:
     types: [published]
 
 jobs:
+
+  list-test-dirs:
+    if: github.repository == 'hidet-org/hidet'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+
+      - name: Checkout Hidet
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+
+      - id: set-matrix
+        run: |
+          python .github/scripts/set_test_matrix.py
+
   publish-tests:
     name: Release Tests
+    needs: list-test-dirs
     if: github.repository == 'hidet-org/hidet'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.list-test-dirs.outputs.matrix) }}
     runs-on: arc-runner-set
     container:
       image: nvcr.io/nvidia/pytorch:24.04-py3
@@ -42,8 +66,7 @@ jobs:
       # Run tests
       - name: Run tests
         run: |
-          python -m pytest -v --durations=20 --clear-cache ./tests
-
+          python -m pytest -v --durations=20 --clear-cache ${{ matrix.path }}
 
   build-docs:
     if: github.repository == 'hidet-org/hidet'

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -30,9 +30,6 @@ jobs:
     name: Release Tests
     needs: list-test-dirs
     if: github.repository == 'hidet-org/hidet'
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.list-test-dirs.outputs.matrix) }}

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,7 +1,6 @@
 name: Publish to PyPI
 
 on:
-  pull_request:
   release:
     types: [published]
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install docs dependencies
         run: |
           pip install -r docs/requirements.txt
-    
+
       - name: Build docs
         run: |
           cd docs; make clean; make html


### PR DESCRIPTION
Updates **release** workflow to run tests in the same way **tests** workflow run for each pr. 


validated on [this](https://github.com/hidet-org/hidet/actions/runs/10098384646) run. 
didn't let it run all the way.. but the last step was not changed. 