### PR TITLE
[BUG] FIx bug with f16 overfloat 

### DIFF
--- a/python/hidet/graph/ops/quant/symmetric.py
+++ b/python/hidet/graph/ops/quant/symmetric.py
@@ -27,11 +27,13 @@ class SymmetricQuantizationTask(Task):
         if not isinstance(dims, (list, tuple)):
             dims = [dims]
 
-        # bf16 can't hold int16.max_value. Should convert to f32 first. 
-        # For another types pair is similar. 
+        # bf16 can't hold int16.max_value. Should convert to f32 first.
+        # For another types pair is similar.
         # For cases when float type can hold quant_type.max_value we can skip this step but leave it for simplicity
-        wm = compute(name='abs', shape=w.shape, 
-            fcompute=lambda *indices: if_then_else(w[indices] >= 0, cast(w[indices], f32), cast(-w[indices], f32))
+        wm = compute(
+            name='abs',
+            shape=w.shape,
+            fcompute=lambda *indices: if_then_else(w[indices] >= 0, cast(w[indices], f32), cast(-w[indices], f32)),
         )
 
         scale = cops.reduce(wm, dims, keep_dim=False, reduce_type='max')


### PR DESCRIPTION
Add preliminary conversion to `f32` for quantization. 

Describe on example  `f16` quantize to `int16` (it is a bit unclear why we need it but we support it and test it). `f16` can not hold exact value of `int16.max_value` and we got `f16` number that more than `int16.max_value`. In result we got `max_min` value in quantized `int16` instead of `max_int`.

In fact, converting a float to an int can have unpredictable behavior when the float exceeds the maximum value that the target int can hold.
