### PR TITLE
[CI] Add permissions.contents: read to all Workflows

### DIFF
--- a/.github/workflows/launch.yaml
+++ b/.github/workflows/launch.yaml
@@ -1,5 +1,7 @@
 name: Launch CI
 
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,8 @@
 name: Format & Lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/publish-centml-pypi.yaml
+++ b/.github/workflows/publish-centml-pypi.yaml
@@ -1,5 +1,8 @@
 name: Publish to CentML Internal PyPI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,5 +1,8 @@
 name: Publish to PyPI
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -1,5 +1,8 @@
 name: Regression
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
The GitHub Automated Code Security Scanning tool recommended that we explicitly set permissions to all Workflows.

- Adding `permissions.contents: read` to all Workflows since none of them make changes to the repository. All workflows only read repository contents. Alert example: https://github.com/hidet-org/hidet/security/code-scanning/20